### PR TITLE
Add support for class decorators for `@Public` and `@Optional`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ export class UserController {
 }
 ```
 
+Alternatively, use it as a class decorator to specify access for an entire controller:
+```ts title="app.controller.ts"
+import { Controller, Get } from '@nestjs/common';
+import { Public, Optional } from '@thallesp/nestjs-better-auth';
+
+@Public() // All routes inside this controller are public
+@Controller('public')
+export class PublicController { /* */ }
+
+@Optional() // Authentication is optional for all routes inside this controller
+@Controller('optional')
+export class OptionalController { /* */ }
+```
+
 ### Hook Decorators
 
 Create custom hooks that integrate with NestJS's dependency injection:

--- a/src/auth-guard.ts
+++ b/src/auth-guard.ts
@@ -42,11 +42,17 @@ export class AuthGuard implements CanActivate {
 		request.session = session;
 		request.user = session?.user ?? null; // useful for observability tools like Sentry
 
-		const isPublic = this.reflector.get("PUBLIC", context.getHandler());
+		const isPublic = this.reflector.getAllAndOverride<boolean>("PUBLIC", [
+      context.getHandler(),
+      context.getClass(),
+    ]);
 
 		if (isPublic) return true;
 
-		const isOptional = this.reflector.get("OPTIONAL", context.getHandler());
+		const isOptional = this.reflector.getAllAndOverride<boolean>("OPTIONAL", [
+			context.getHandler(),
+			context.getClass(),
+		]);
 
 		if (isOptional && !session) return true;
 

--- a/src/auth-guard.ts
+++ b/src/auth-guard.ts
@@ -43,9 +43,9 @@ export class AuthGuard implements CanActivate {
 		request.user = session?.user ?? null; // useful for observability tools like Sentry
 
 		const isPublic = this.reflector.getAllAndOverride<boolean>("PUBLIC", [
-      context.getHandler(),
-      context.getClass(),
-    ]);
+			context.getHandler(),
+			context.getClass(),
+		]);
 
 		if (isPublic) return true;
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -6,14 +6,16 @@ import { AFTER_HOOK_KEY, BEFORE_HOOK_KEY, HOOK_KEY } from "./symbols.ts";
  * Marks a route or a controller as public, allowing unauthenticated access.
  * When applied, the AuthGuard will skip authentication checks.
  */
-export const Public = (): CustomDecorator<string> => SetMetadata("PUBLIC", true);
+export const Public = (): CustomDecorator<string> =>
+	SetMetadata("PUBLIC", true);
 
 /**
  * Marks a route or a controller as having optional authentication.
  * When applied, the AuthGuard will allow the request to proceed
  * even if no session is present.
  */
-export const Optional = (): CustomDecorator<string> => SetMetadata("OPTIONAL", true);
+export const Optional = (): CustomDecorator<string> =>
+	SetMetadata("OPTIONAL", true);
 
 /**
  * Parameter decorator that extracts the user session from the request.

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,19 +1,19 @@
 import { createParamDecorator, SetMetadata } from "@nestjs/common";
-import type { ExecutionContext } from "@nestjs/common";
+import type { CustomDecorator, ExecutionContext } from "@nestjs/common";
 import { AFTER_HOOK_KEY, BEFORE_HOOK_KEY, HOOK_KEY } from "./symbols.ts";
 
 /**
- * Marks a route as public, allowing unauthenticated access.
- * When applied to a controller method, the AuthGuard will skip authentication checks.
+ * Marks a route or a controller as public, allowing unauthenticated access.
+ * When applied, the AuthGuard will skip authentication checks.
  */
-export const Public = (): MethodDecorator => SetMetadata("PUBLIC", true);
+export const Public = (): CustomDecorator<string> => SetMetadata("PUBLIC", true);
 
 /**
- * Marks a route as having optional authentication.
- * When applied to a controller method, the AuthGuard will allow the request to proceed
+ * Marks a route or a controller as having optional authentication.
+ * When applied, the AuthGuard will allow the request to proceed
  * even if no session is present.
  */
-export const Optional = (): MethodDecorator => SetMetadata("OPTIONAL", true);
+export const Optional = (): CustomDecorator<string> => SetMetadata("OPTIONAL", true);
 
 /**
  * Parameter decorator that extracts the user session from the request.


### PR DESCRIPTION
Allows `@Public()` and `@Optional()` to be used as class decorators. That way, an entire controller can be marked as public/optional without having to mark individual routes.

```ts
@Public()
@Controller('public')
class PublicController { /* ... */ }
```