### PR TITLE
fix: correct session decorator type

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -21,7 +21,7 @@ export const Optional = (): CustomDecorator<string> =>
  * Parameter decorator that extracts the user session from the request.
  * Provides easy access to the authenticated user's session data in controller methods.
  */
-export const Session: ParameterDecorator = createParamDecorator(
+export const Session: ReturnType<typeof createParamDecorator> = createParamDecorator(
 	(_data: unknown, context: ExecutionContext): unknown => {
 		const request = context.switchToHttp().getRequest();
 		return request.session;


### PR DESCRIPTION
# Description 
The types for the `Session` decorator were incorrect as they were marked as `const Session: ParameterDecorator`. This leads to type errors when used, as the call signature of the `ParameterDecorator` requires arguments for target and more. This PR fixes that by pinning off the return type of `createParamDecorator`

Resolves #6 