### PR TITLE
fix: remove `req.url` override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,9 @@
       },
     },
   },
+  "overrides": {
+    "better-call": "^1.0.15",
+  },
   "packages": {
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
@@ -188,7 +191,7 @@
 
     "better-auth": ["better-auth@1.2.9", "", { "dependencies": { "@better-auth/utils": "0.2.5", "@better-fetch/fetch": "^1.1.18", "@noble/ciphers": "^0.6.0", "@noble/hashes": "^1.6.1", "@simplewebauthn/browser": "^13.0.0", "@simplewebauthn/server": "^13.0.0", "better-call": "^1.0.8", "defu": "^6.1.4", "jose": "^5.9.6", "kysely": "^0.28.2", "nanostores": "^0.11.3", "zod": "^3.24.1" } }, "sha512-WLqBXDzuaCQetQctLGC5oTfGmL32zUvxnM4Y+LZkhwseMaZWq5EKI+c/ZATgz2YkFt7726q659PF8CfB9P1VuA=="],
 
-    "better-call": ["better-call@1.0.9", "", { "dependencies": { "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-Qfm0gjk0XQz0oI7qvTK1hbqTsBY4xV2hsHAxF8LZfUYl3RaECCIifXuVqtPpZJWvlCCMlQSvkvhhyuApGUba6g=="],
+    "better-call": ["better-call@1.0.15", "", { "dependencies": { "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-u4ZNRB1yBx5j3CltTEbY2ZoFPVcgsuvciAqTEmPvnZpZ483vlZf4LGJ5aVau1yMlrvlyHxOCica3OqXBLhmsUw=="],
 
     "body-parser": ["body-parser@1.20.3", "", { "dependencies": { "bytes": "3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "on-finished": "2.4.1", "qs": "6.13.0", "raw-body": "2.5.2", "type-is": "~1.6.18", "unpipe": "1.0.0" } }, "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g=="],
 

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
 		"@nestjs/core": "^11.0.10",
 		"better-auth": "^1.2.8",
 		"express": "^5.0.0"
+	},
+	"overrides": {
+		"better-call": "^1.0.15"
 	}
 }

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -127,8 +127,6 @@ export class AuthModule implements NestModule, OnModuleInit {
 			// little hack to ignore any global prefix
 			// for now i'll just not support a global prefix
 			.use(`${basePath}/*path`, (req: Request, res: Response) => {
-				req.url = req.originalUrl;
-
 				return handler(req, res);
 			});
 		this.logger.log(`AuthModule initialized BetterAuth on '${basePath}/*'`);


### PR DESCRIPTION
Fixes #20

Since https://github.com/Bekacru/better-call/pull/32, better-call assumes `req.url` is relative to the subrouter used. This meant that the override of `req.url` with `req.url = req.originalUrl` was effectively converting the resulting url parsed by better-call to `'/api/auth/api/auth/*'`.

This PR aligns this package with the change in behaviour by better-call. 

It also explicitly overrides the version of better-call since it's a transitive dependency and the change introduced in this PR introduces 404 errors for versions `<1.0.15`. This can be removed if/when `better-auth` bumps their version requirements for `better-call`