### PR TITLE
fix: export symbols

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./decorators.ts";
 export * from "./auth-service.ts";
 export * from "./auth-guard.ts";
 export * from "./auth-module.ts";
+export * from "./symbols.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@ export * from "./decorators.ts";
 export * from "./auth-service.ts";
 export * from "./auth-guard.ts";
 export * from "./auth-module.ts";
-export * from "./symbols.js";
+export * from "./symbols.ts";


### PR DESCRIPTION
For making custom guards, we need to use these symbols. And since this lib uses `Symbol` and not `Symbol.for` so there's no way to recreate it. So exporting them is required