### PR TITLE
feat: add forRootAsync

### DIFF
--- a/src/api-error-exception-filter.ts
+++ b/src/api-error-exception-filter.ts
@@ -1,0 +1,19 @@
+import type { ArgumentsHost } from "@nestjs/common";
+import type { ExceptionFilter } from "@nestjs/common";
+import { APIError } from "better-auth/api";
+import type { Response } from "express";
+
+export class APIErrorExceptionFilter implements ExceptionFilter {
+	catch(exception: APIError, host: ArgumentsHost): void {
+		console.log("im getting called");
+		const ctx = host.switchToHttp();
+		const response = ctx.getResponse<Response>();
+		const status = exception.statusCode;
+		const message = exception.body?.message;
+
+		response.status(status).json({
+			statusCode: status,
+			message,
+		});
+	}
+}

--- a/src/auth-module-definition.ts
+++ b/src/auth-module-definition.ts
@@ -27,10 +27,12 @@ export const { ConfigurableModuleClass, OPTIONS_TYPE, ASYNC_OPTIONS_TYPE } =
 			(def, extras) => {
 				const providers = def.providers ?? [];
 
-				providers.push({
-					provide: APP_FILTER,
-					useClass: APIErrorExceptionFilter,
-				});
+				if (!extras.disableExceptionFilter) {
+					providers.push({
+						provide: APP_FILTER,
+						useClass: APIErrorExceptionFilter,
+					});
+				}
 
 				return {
 					...def,

--- a/src/auth-module-definition.ts
+++ b/src/auth-module-definition.ts
@@ -1,5 +1,7 @@
 import { ConfigurableModuleBuilder } from "@nestjs/common";
 import type { Auth } from "./auth-module.ts";
+import { APP_FILTER } from "@nestjs/core";
+import { APIErrorExceptionFilter } from "./api-error-exception-filter.ts";
 
 export type AuthModuleOptions<A = Auth> = {
 	auth: A;
@@ -23,9 +25,17 @@ export const { ConfigurableModuleClass, OPTIONS_TYPE, ASYNC_OPTIONS_TYPE } =
 				disableBodyParser: false,
 			},
 			(def, extras) => {
+				const providers = def.providers ?? [];
+
+				providers.push({
+					provide: APP_FILTER,
+					useClass: APIErrorExceptionFilter,
+				});
+
 				return {
 					...def,
 					exports: [MODULE_OPTIONS_TOKEN],
+					providers,
 					global: extras.isGlobal,
 				};
 			},

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -24,7 +24,6 @@ import {
 import { AuthService } from "./auth-service.ts";
 import { SkipBodyParsingMiddleware } from "./middlewares.ts";
 import { AFTER_HOOK_KEY, BEFORE_HOOK_KEY, HOOK_KEY } from "./symbols.ts";
-import { APIError } from "better-auth/api";
 
 const HOOKS = [
 	{ metadataKey: BEFORE_HOOK_KEY, hookType: "before" as const },
@@ -127,20 +126,8 @@ export class AuthModule
 			.getInstance()
 			// little hack to ignore any global prefix
 			// for now i'll just not support a global prefix
-			.use(`${basePath}/*path`, async (req: Request, res: Response) => {
-				return await handler(req, res).catch((err) => {
-					// for whatever reason, nestjs' built-in exception filters are not working so I'll go with this for now
-					if (this.options.disableExceptionFilter) throw err;
-
-					if (err instanceof APIError) {
-						return res.status(err.statusCode).json({
-							statusCode: err.statusCode,
-							message: err.message,
-						});
-					}
-
-					throw err;
-				});
+			.use(`${basePath}/*path`, (req: Request, res: Response) => {
+				return handler(req, res);
 			});
 		this.logger.log(`AuthModule initialized BetterAuth on '${basePath}/*'`);
 	}


### PR DESCRIPTION
this was mostly done in https://github.com/ThallesP/nestjs-better-auth/pull/27. all i did was branch off of f66c39170ab39aa0022d87fed7d1bc5c284e0812 and fix the logic.

I've confirmed that this works when setting `disableExceptionFilter` to `true` or `false` and manually triggering an APIError
```
    AuthModule.forRootAsync({
      disableExceptionFilter: false,
      useFactory: async () => {
        return {
          auth: betterAuth({}),
        }
      },
    }),
```