### PR TITLE
fix: make BeforeHook/AfterHook decorators work

### DIFF
--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -65,10 +65,6 @@ export class AuthModule
 	onModuleInit(): void {
 		if (!this.options.auth.options.hooks) return;
 
-		this.options.auth.options.hooks = {
-			...this.options.auth.options.hooks,
-		};
-
 		const providers = this.discoveryService
 			.getProviders()
 			.filter(
@@ -138,8 +134,6 @@ export class AuthModule
 		providerMethod: (...args: unknown[]) => unknown,
 		providerClass: { new (...args: unknown[]): unknown },
 	) {
-		if (!this.options.auth.options.hooks) return;
-
 		for (const { metadataKey, hookType } of HOOKS) {
 			const hasHook = Reflect.hasMetadata(metadataKey, providerMethod);
 			if (!hasHook) continue;

--- a/tests/e2e/hook.e2e.test.ts
+++ b/tests/e2e/hook.e2e.test.ts
@@ -1,0 +1,106 @@
+import request from "supertest";
+import { faker } from "@faker-js/faker";
+import { INestApplication, Injectable, Module } from "@nestjs/common";
+import {
+  AfterHook,
+  AuthHookContext,
+  BeforeHook,
+  Hook,
+} from "../../src/decorators.ts";
+import { Test } from "@nestjs/testing";
+import { AuthModule } from "../../src/index.ts";
+import { ExpressAdapter } from "@nestjs/platform-express";
+import { betterAuth } from "better-auth";
+
+@Hook()
+@Injectable()
+class SignUpHook {
+  public beforeHookCalled = false;
+  public afterHookCalled = false;
+
+  @BeforeHook("/sign-up/email")
+  async beforeHookHandler(ctx: AuthHookContext) {
+    console.log("beforeHookCalled");
+    this.beforeHookCalled = true;
+    return ctx;
+  }
+
+  @AfterHook("/sign-up/email")
+  async afterHookHandler(ctx: AuthHookContext) {
+    this.afterHookCalled = true;
+    return ctx;
+  }
+}
+
+describe("hook e2e", () => {
+  let app: INestApplication;
+  let signUpHook: SignUpHook;
+
+  beforeAll(async () => {
+    const auth = betterAuth({
+      emailAndPassword: { enabled: true },
+      hooks: {},
+    });
+
+    @Module({
+      imports: [AuthModule.forRoot({ auth })],
+      providers: [SignUpHook],
+    })
+    class AppModule { }
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication(new ExpressAdapter(), {
+      bodyParser: false,
+    });
+
+    // Get the hook instance to check if it was called
+    signUpHook = moduleRef.get<SignUpHook>(SignUpHook);
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("should call @BeforeHook", async () => {
+    // Reset hook call flags
+    signUpHook.beforeHookCalled = false;
+    signUpHook.afterHookCalled = false;
+
+    await request(app.getHttpServer())
+      .post("/api/auth/sign-up/email")
+      .set("Content-Type", "application/json")
+      .send({
+        name: faker.person.fullName,
+        email: faker.internet.email(),
+        password: faker.internet.password(),
+      })
+      .expect(200);
+
+    // Verify that the before hook was called
+    expect(signUpHook.beforeHookCalled).toBe(true);
+  });
+
+  it("should call @AfterHook", async () => {
+    // Reset hook call flags
+    signUpHook.beforeHookCalled = false;
+    signUpHook.afterHookCalled = false;
+
+    await request(app.getHttpServer())
+      .post("/api/auth/sign-up/email")
+      .set("Content-Type", "application/json")
+      .send({
+        name: faker.person.fullName,
+        email: faker.internet.email(),
+        password: faker.internet.password(),
+      })
+      .expect(200);
+
+    // Verify that the after hook was called
+    expect(signUpHook.afterHookCalled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Fix: Make BeforeHook/AfterHook decorators work

Fixes #42

### Problem
`@BeforeHook` and `@AfterHook` were not firing.

### Root Cause
A shallow copy of the hooks object in `onModuleInit()` was overwriting the hooks configuration, preventing registration.

### Solution
Removed the problematic shallow copy and the redundant hooks check in `setupHooks()`.

### Changes
- Removed `this.options.auth.options.hooks = { ...this.options.auth.options.hooks }` from `onModuleInit()`
- Removed redundant `if (!this.options.auth.options.hooks) return;` check in `setupHooks()`
- Added e2e tests to verify hook behavior

### Testing
- Added tests for `@BeforeHook` and `@AfterHook`
- Verified hooks fire on auth endpoints
- All tests pass

This resolves the issue reported in #42 and enables hook decorators to work as intended.