### PR TITLE
Fix role check for cases where multiple roles are separated by a comma

### DIFF
--- a/src/auth-guard.ts
+++ b/src/auth-guard.ts
@@ -90,7 +90,9 @@ export class AuthGuard implements CanActivate {
 			if (Array.isArray(userRole)) {
 				hasRole = userRole.some((role) => requiredRoles.includes(role));
 			} else if (typeof userRole === "string") {
-				hasRole = userRole.split(",").some((role) => requiredRoles.includes(role));
+				hasRole = userRole
+					.split(",")
+					.some((role) => requiredRoles.includes(role));
 			}
 
 			if (!hasRole) {


### PR DESCRIPTION
There is a bug on the role check, where if a user has multiple roles **as string**, the check will return false even if the user has the role.

This PR fixes this by spliting the roles by comma (default separator with the admin plugin and organization plugin ), making it into an array and checking if the the user has the role.

Tested using the admin plugin