### PR TITLE
feat: make @nestjs/websockets an optional peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,9 @@
         "graphql": "^16.11.0",
         "typescript": "^5.9.2",
       },
+      "optionalPeers": [
+        "@nestjs/websockets",
+      ],
     },
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -66,5 +66,10 @@
 		"express": "^5.1.0",
 		"graphql": "^16.11.0",
 		"typescript": "^5.9.2"
+	},
+	"peerDependenciesMeta": {
+		"@nestjs/websockets": {
+			"optional": true
+		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR makes `@nestjs/websockets` a truly optional peer dependency by lazy-loading `WsException` only when a WebSocket context is encountered.

## Problem

Currently, `@nestjs/websockets` is listed as a peer dependency and imported at the module level in `auth-guard.ts`, which means:
- Applications that don't use WebSockets still need to install `@nestjs/websockets` and `@nestjs/platform-socket.io`
- This increases bundle size and dependency footprint unnecessarily
- It breaks applications during build/test phase when these packages aren't installed

## Solution

- Remove the static import of `WsException` from `@nestjs/websockets`
- Implement lazy-loading using `require()` only when WebSocket context is detected
- Add `peerDependenciesMeta` to mark `@nestjs/websockets` as optional
- Provide a helpful error message when WebSocket packages are needed but missing

## Benefits

- **Reduced dependencies**: Applications using only HTTP/GraphQL don't need WebSocket packages
- **Smaller bundle size**: No need to include WebSocket libraries when not used
- **Better developer experience**: Clear error message when WebSocket support is needed but not installed
- **Backward compatible**: Existing applications with WebSocket support continue to work unchanged

## Testing

All existing tests pass, including the WebSocket authentication tests:

```
bun test
✓ 22 pass
✓ 0 fail
```

## Related Issues

This addresses the issue where test workflows fail with:
```
Error: Cannot find package '@nestjs/websockets' imported from node_modules/@thallesp/nestjs-better-auth/dist/index.mjs
```

Fixes: https://github.com/fullstackhouse/tournee-api/actions/runs/19704193653