### PR TITLE
fix: handle Better Auth or middleware errors in fallback

### DIFF
--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -130,14 +130,14 @@ export class AuthModule
 		}
 
 		const handler = toNodeHandler(this.options.auth);
-		this.adapter.httpAdapter
-			.getInstance()
-			.use(basePath, (req: Request, res: Response) => {
+		consumer
+			.apply((req: Request, res: Response) => {
 				if (this.options.middleware) {
 					return this.options.middleware(req, res, () => handler(req, res));
 				}
 				return handler(req, res);
-			});
+			})
+			.forRoutes(basePath);
 		this.logger.log(`AuthModule initialized BetterAuth on '${basePath}'`);
 	}
 


### PR DESCRIPTION
If Better Auth or middleware throws an error, we should have a fallback to handle the error gracefully by returning a 500 response (NestJS default).

This is how I encountered this issue:
- installed global middleware provided by https://github.com/iamolegga/nestjs-pino
- logs for Better Auth routes were not being logged
- manually added the pino middleware in the AuthModule `middleware` option
- logs for Better Auth routes were then being logged
- set the `X-Forwarded-Proto` header to `https, https` in a `/api/auth/sign-in/social` request
- that throws an uncaught `TypeError: Failed to parse URL from https` in `better-call`
- the entire NestJS application crashed

Admittedly, the uncaught error is a `better-call` issue, but other uncaught errors could be thrown by middleware. Ultimately, the `nestjs-better-auth` module should have a fallback to prevent the crash and handle the error according to NestJS paradigms.

A bonus of this change is that I don't need to manually add this pino middleware in the AuthModule `middleware` option. All globally registered middleware will now be applied to Better Auth routes. Only middleware that should exclusively apply to Better Auth routes needs to be added to the AuthModule `middleware` option.

- related to the exception filter chat in #27