### PR TITLE
fix(middleware): mount Better Auth middleware on basePath

### DIFF
--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -1,25 +1,25 @@
 import { Inject, Logger, Module } from "@nestjs/common";
 import type {
-	DynamicModule,
-	MiddlewareConsumer,
-	NestModule,
-	OnModuleInit,
+  DynamicModule,
+  MiddlewareConsumer,
+  NestModule,
+  OnModuleInit,
 } from "@nestjs/common";
 import {
-	DiscoveryModule,
-	DiscoveryService,
-	HttpAdapterHost,
-	MetadataScanner,
+  DiscoveryModule,
+  DiscoveryService,
+  HttpAdapterHost,
+  MetadataScanner,
 } from "@nestjs/core";
 import { toNodeHandler } from "better-auth/node";
 import { createAuthMiddleware } from "better-auth/plugins";
 import type { Request, Response } from "express";
 import {
-	type ASYNC_OPTIONS_TYPE,
-	type AuthModuleOptions,
-	ConfigurableModuleClass,
-	MODULE_OPTIONS_TOKEN,
-	type OPTIONS_TYPE,
+  type ASYNC_OPTIONS_TYPE,
+  type AuthModuleOptions,
+  ConfigurableModuleClass,
+  MODULE_OPTIONS_TOKEN,
+  type OPTIONS_TYPE,
 } from "./auth-module-definition.ts";
 import { AuthService } from "./auth-service.ts";
 import { SkipBodyParsingMiddleware } from "./middlewares.ts";
@@ -28,8 +28,8 @@ import { AuthGuard } from "./auth-guard.ts";
 import { APP_GUARD } from "@nestjs/core";
 
 const HOOKS = [
-	{ metadataKey: BEFORE_HOOK_KEY, hookType: "before" as const },
-	{ metadataKey: AFTER_HOOK_KEY, hookType: "after" as const },
+  { metadataKey: BEFORE_HOOK_KEY, hookType: "before" as const },
+  { metadataKey: AFTER_HOOK_KEY, hookType: "after" as const },
 ];
 
 // biome-ignore lint/suspicious/noExplicitAny: i don't want to cause issues/breaking changes between different ways of setting up better-auth and even versions
@@ -40,194 +40,213 @@ export type Auth = any;
  * Provides authentication middleware, hooks, and exception handling.
  */
 @Module({
-	imports: [DiscoveryModule],
-	providers: [AuthService],
-	exports: [AuthService],
+  imports: [DiscoveryModule],
+  providers: [AuthService],
+  exports: [AuthService],
 })
 export class AuthModule
-	extends ConfigurableModuleClass
-	implements NestModule, OnModuleInit
+  extends ConfigurableModuleClass
+  implements NestModule, OnModuleInit
 {
-	private readonly logger = new Logger(AuthModule.name);
-	constructor(
-		@Inject(DiscoveryService)
-		private readonly discoveryService: DiscoveryService,
-		@Inject(MetadataScanner)
-		private readonly metadataScanner: MetadataScanner,
-		@Inject(HttpAdapterHost)
-		private readonly adapter: HttpAdapterHost,
-		@Inject(MODULE_OPTIONS_TOKEN)
-		private readonly options: AuthModuleOptions,
-	) {
-		super();
-	}
+  private readonly logger = new Logger(AuthModule.name);
+  constructor(
+    @Inject(DiscoveryService)
+    private readonly discoveryService: DiscoveryService,
+    @Inject(MetadataScanner)
+    private readonly metadataScanner: MetadataScanner,
+    @Inject(HttpAdapterHost)
+    private readonly adapter: HttpAdapterHost,
+    @Inject(MODULE_OPTIONS_TOKEN)
+    private readonly options: AuthModuleOptions
+  ) {
+    super();
+  }
 
-	onModuleInit(): void {
-		const providers = this.discoveryService
-			.getProviders()
-			.filter(
-				({ metatype }) => metatype && Reflect.getMetadata(HOOK_KEY, metatype),
-			);
+  onModuleInit(): void {
+    const providers = this.discoveryService
+      .getProviders()
+      .filter(
+        ({ metatype }) => metatype && Reflect.getMetadata(HOOK_KEY, metatype)
+      );
 
-		const hasHookProviders = providers.length > 0;
-		const hooksConfigured =
-			typeof this.options.auth?.options?.hooks === "object";
+    const hasHookProviders = providers.length > 0;
+    const hooksConfigured =
+      typeof this.options.auth?.options?.hooks === "object";
 
-		if (hasHookProviders && !hooksConfigured)
-			throw new Error(
-				"Detected @Hook providers but Better Auth 'hooks' are not configured. Add 'hooks: {}' to your betterAuth(...) options.",
-			);
+    if (hasHookProviders && !hooksConfigured)
+      throw new Error(
+        "Detected @Hook providers but Better Auth 'hooks' are not configured. Add 'hooks: {}' to your betterAuth(...) options."
+      );
 
-		if (!hooksConfigured) return;
+    if (!hooksConfigured) return;
 
-		for (const provider of providers) {
-			const providerPrototype = Object.getPrototypeOf(provider.instance);
-			const methods = this.metadataScanner.getAllMethodNames(providerPrototype);
+    for (const provider of providers) {
+      const providerPrototype = Object.getPrototypeOf(provider.instance);
+      const methods = this.metadataScanner.getAllMethodNames(providerPrototype);
 
-			for (const method of methods) {
-				const providerMethod = providerPrototype[method];
-				this.setupHooks(providerMethod, provider.instance);
-			}
-		}
-	}
+      for (const method of methods) {
+        const providerMethod = providerPrototype[method];
+        this.setupHooks(providerMethod, provider.instance);
+      }
+    }
+  }
 
-	configure(consumer: MiddlewareConsumer): void {
-		if (this.options?.disableControllers) return;
+  configure(consumer: MiddlewareConsumer): void {
+    if (this.options?.disableControllers) return;
 
-		const trustedOrigins = this.options.auth.options.trustedOrigins;
-		// function-based trustedOrigins requires a Request (from web-apis) object to evaluate, which is not available in NestJS (we only have a express Request object)
-		// if we ever need this, take a look at better-call which show an implementation for this
-		const isNotFunctionBased = trustedOrigins && Array.isArray(trustedOrigins);
+    const trustedOrigins = this.options.auth.options.trustedOrigins;
+    // function-based trustedOrigins requires a Request (from web-apis) object to evaluate, which is not available in NestJS (we only have a express Request object)
+    // if we ever need this, take a look at better-call which show an implementation for this
+    const isNotFunctionBased = trustedOrigins && Array.isArray(trustedOrigins);
 
-		if (!this.options.disableTrustedOriginsCors && isNotFunctionBased) {
-			this.adapter.httpAdapter.enableCors({
-				origin: trustedOrigins,
-				methods: ["GET", "POST", "PUT", "DELETE"],
-				credentials: true,
-			});
-		} else if (
-			trustedOrigins &&
-			!this.options.disableTrustedOriginsCors &&
-			!isNotFunctionBased
-		)
-			throw new Error(
-				"Function-based trustedOrigins not supported in NestJS. Use string array or disable CORS with disableTrustedOriginsCors: true.",
-			);
+    if (!this.options.disableTrustedOriginsCors && isNotFunctionBased) {
+      this.adapter.httpAdapter.enableCors({
+        origin: trustedOrigins,
+        methods: ["GET", "POST", "PUT", "DELETE"],
+        credentials: true,
+      });
+    } else if (
+      trustedOrigins &&
+      !this.options.disableTrustedOriginsCors &&
+      !isNotFunctionBased
+    )
+      throw new Error(
+        "Function-based trustedOrigins not supported in NestJS. Use string array or disable CORS with disableTrustedOriginsCors: true."
+      );
 
-		// Get basePath from options or use default
-		let basePath = this.options.auth.options.basePath ?? "/api/auth";
+    // Get basePath from options or use default
+    let basePath = this.options.auth.options.basePath ?? "/api/auth";
 
-		// Ensure basePath starts with /
-		if (!basePath.startsWith("/")) {
-			basePath = `/${basePath}`;
-		}
+    // Ensure basePath starts with /
+    if (!basePath.startsWith("/")) {
+      basePath = `/${basePath}`;
+    }
 
-		// Ensure basePath doesn't end with /
-		if (basePath.endsWith("/")) {
-			basePath = basePath.slice(0, -1);
-		}
+    // Ensure basePath doesn't end with /
+    if (basePath.endsWith("/")) {
+      basePath = basePath.slice(0, -1);
+    }
 
-		if (!this.options.disableBodyParser) {
-			consumer.apply(SkipBodyParsingMiddleware(basePath)).forRoutes("*path");
-		}
+    // Detect Express major version to use the correct wildcard syntax.
+    // Express 5 uses named wildcard `/*path`, while Express 4 uses `/*`.
+    let expressVersion = "4.0.0";
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+      expressVersion = require("express/package.json").version as string;
+    } catch {
+      // if require fails, assume Express 4.x (default for Nest projects)
+      expressVersion = "4.0.0";
+    }
 
-		const handler = toNodeHandler(this.options.auth);
-		this.adapter.httpAdapter
-			.getInstance()
-			// little hack to ignore any global prefix
-			// for now i'll just not support a global prefix
-			.use(`${basePath}/*path`, (req: Request, res: Response) => {
-				if (this.options.middleware) {
-					return this.options.middleware(req, res, () => handler(req, res));
-				}
-				return handler(req, res);
-			});
-		this.logger.log(`AuthModule initialized BetterAuth on '${basePath}/*'`);
-	}
+    const isExpress5 = expressVersion.startsWith("5.");
 
-	private setupHooks(
-		providerMethod: (...args: unknown[]) => unknown,
-		providerClass: { new (...args: unknown[]): unknown },
-	) {
-		if (!this.options.auth.options.hooks) return;
+    // Mount the skip-body middleware and the Better Auth handler directly
+    // on the adapter's Express instance at `basePath`. Using `app.use(basePath, ...)`
+    // matches the base path and all subpaths on both Express 4 and 5.
+    if (!this.options.disableBodyParser) {
+      this.adapter.httpAdapter
+        .getInstance()
+        .use(basePath, SkipBodyParsingMiddleware(basePath));
+    }
 
-		for (const { metadataKey, hookType } of HOOKS) {
-			const hasHook = Reflect.hasMetadata(metadataKey, providerMethod);
-			if (!hasHook) continue;
+    const handler = toNodeHandler(this.options.auth);
 
-			const hookPath = Reflect.getMetadata(metadataKey, providerMethod);
+    this.adapter.httpAdapter
+      .getInstance()
+      // little hack to ignore any global prefix
+      // for now i'll just not support a global prefix
+      .use(basePath, (req: Request, res: Response) => {
+        if (this.options.middleware) {
+          return this.options.middleware(req, res, () => handler(req, res));
+        }
+        return handler(req, res);
+      });
+    this.logger.log(`AuthModule initialized BetterAuth on '${basePath}'`);
+  }
 
-			const originalHook = this.options.auth.options.hooks[hookType];
-			this.options.auth.options.hooks[hookType] = createAuthMiddleware(
-				async (ctx) => {
-					if (originalHook) {
-						await originalHook(ctx);
-					}
+  private setupHooks(
+    providerMethod: (...args: unknown[]) => unknown,
+    providerClass: { new (...args: unknown[]): unknown }
+  ) {
+    if (!this.options.auth.options.hooks) return;
 
-					if (hookPath && hookPath !== ctx.path) return;
+    for (const { metadataKey, hookType } of HOOKS) {
+      const hasHook = Reflect.hasMetadata(metadataKey, providerMethod);
+      if (!hasHook) continue;
 
-					await providerMethod.apply(providerClass, [ctx]);
-				},
-			);
-		}
-	}
+      const hookPath = Reflect.getMetadata(metadataKey, providerMethod);
 
-	static forRootAsync(options: typeof ASYNC_OPTIONS_TYPE): DynamicModule {
-		const forRootAsyncResult = super.forRootAsync(options);
-		return {
-			...forRootAsyncResult,
-			controllers: options.disableControllers
-				? []
-				: forRootAsyncResult.controllers,
-			providers: [
-				...(forRootAsyncResult.providers ?? []),
-				...(!options.disableGlobalAuthGuard
-					? [
-							{
-								provide: APP_GUARD,
-								useClass: AuthGuard,
-							},
-						]
-					: []),
-			],
-		};
-	}
+      const originalHook = this.options.auth.options.hooks[hookType];
+      this.options.auth.options.hooks[hookType] = createAuthMiddleware(
+        async (ctx) => {
+          if (originalHook) {
+            await originalHook(ctx);
+          }
 
-	static forRoot(options: typeof OPTIONS_TYPE): DynamicModule;
-	/**
-	 * @deprecated Use the object-based signature: AuthModule.forRoot({ auth, ...options })
-	 */
-	static forRoot(
-		auth: Auth,
-		options?: Omit<typeof OPTIONS_TYPE, "auth">,
-	): DynamicModule;
-	static forRoot(
-		arg1: Auth | typeof OPTIONS_TYPE,
-		arg2?: Omit<typeof OPTIONS_TYPE, "auth">,
-	): DynamicModule {
-		const normalizedOptions: typeof OPTIONS_TYPE =
-			typeof arg1 === "object" && arg1 !== null && "auth" in (arg1 as object)
-				? (arg1 as typeof OPTIONS_TYPE)
-				: ({ ...(arg2 ?? {}), auth: arg1 as Auth } as typeof OPTIONS_TYPE);
+          if (hookPath && hookPath !== ctx.path) return;
 
-		const forRootResult = super.forRoot(normalizedOptions);
+          await providerMethod.apply(providerClass, [ctx]);
+        }
+      );
+    }
+  }
 
-		return {
-			...forRootResult,
-			controllers: normalizedOptions.disableControllers
-				? []
-				: forRootResult.controllers,
-			providers: [
-				...(forRootResult.providers ?? []),
-				...(!normalizedOptions.disableGlobalAuthGuard
-					? [
-							{
-								provide: APP_GUARD,
-								useClass: AuthGuard,
-							},
-						]
-					: []),
-			],
-		};
-	}
+  static forRootAsync(options: typeof ASYNC_OPTIONS_TYPE): DynamicModule {
+    const forRootAsyncResult = super.forRootAsync(options);
+    return {
+      ...forRootAsyncResult,
+      controllers: options.disableControllers
+        ? []
+        : forRootAsyncResult.controllers,
+      providers: [
+        ...(forRootAsyncResult.providers ?? []),
+        ...(!options.disableGlobalAuthGuard
+          ? [
+              {
+                provide: APP_GUARD,
+                useClass: AuthGuard,
+              },
+            ]
+          : []),
+      ],
+    };
+  }
+
+  static forRoot(options: typeof OPTIONS_TYPE): DynamicModule;
+  /**
+   * @deprecated Use the object-based signature: AuthModule.forRoot({ auth, ...options })
+   */
+  static forRoot(
+    auth: Auth,
+    options?: Omit<typeof OPTIONS_TYPE, "auth">
+  ): DynamicModule;
+  static forRoot(
+    arg1: Auth | typeof OPTIONS_TYPE,
+    arg2?: Omit<typeof OPTIONS_TYPE, "auth">
+  ): DynamicModule {
+    const normalizedOptions: typeof OPTIONS_TYPE =
+      typeof arg1 === "object" && arg1 !== null && "auth" in (arg1 as object)
+        ? (arg1 as typeof OPTIONS_TYPE)
+        : ({ ...(arg2 ?? {}), auth: arg1 as Auth } as typeof OPTIONS_TYPE);
+
+    const forRootResult = super.forRoot(normalizedOptions);
+
+    return {
+      ...forRootResult,
+      controllers: normalizedOptions.disableControllers
+        ? []
+        : forRootResult.controllers,
+      providers: [
+        ...(forRootResult.providers ?? []),
+        ...(!normalizedOptions.disableGlobalAuthGuard
+          ? [
+              {
+                provide: APP_GUARD,
+                useClass: AuthGuard,
+              },
+            ]
+          : []),
+      ],
+    };
+  }
 }


### PR DESCRIPTION
Change  to  so the middleware is mounted and runs correctly in Nest + Express integration. This ensures the middleware handles requests under the base path instead of relying on wildcard patterns that may be ignored by the adapter.