### PR TITLE
feat: add enableRawBodyParser option for webhook signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ async function bootstrap() {
 bootstrap();
 ```
 
+> [!IMPORTANT]
+> **Side Effect:** Since we disable NestJS's built-in body parser, the `rawBody: true` option in `NestFactory.create()` has no effect.
+> If you need access to `req.rawBody` (e.g., for webhook signature verification), use the `enableRawBodyParser` option in `AuthModule.forRoot()` instead.
+> See [Module Options](#module-options) for details.
+
 > [!WARNING]  
 > Currently the library has beta support for Fastify, if you experience any issues with it, please open an issue.
 
@@ -389,6 +394,7 @@ AuthModule.forRoot({
   auth,
   disableTrustedOriginsCors: false,
   disableBodyParser: false,
+  enableRawBodyParser: false,
   disableGlobalAuthGuard: false,
   disableControllers: false,
 });
@@ -400,6 +406,7 @@ The available options are:
 | --------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `disableTrustedOriginsCors` | `false` | When set to `true`, disables the automatic CORS configuration for the origins specified in `trustedOrigins`. Use this if you want to handle CORS configuration manually. |
 | `disableBodyParser`         | `false` | When set to `true`, disables the automatic body parser middleware. Use this if you want to handle request body parsing manually.                                         |
+| `enableRawBodyParser`       | `false` | When set to `true`, enables raw body parsing and attaches the raw buffer to `req.rawBody`. Use this for webhook signature verification. **Note:** Since this library disables NestJS's built-in body parser, NestJS's `rawBody: true` option has no effect - use this option instead. |
 | `disableGlobalAuthGuard`    | `false` | When set to `true`, does not register `AuthGuard` as a global guard. Use this if you prefer to apply `AuthGuard` manually or register it yourself via `APP_GUARD`.       |
 | `disableControllers`        | `false` | When set to `true`, does not register any controllers. Use this if you want to handle routes manually.                                                                   |
 | `middleware`                | `undefined` | Optional middleware function that wraps the Better Auth handler. Receives `(req, res, next)` parameters. Useful for integrating with request-scoped libraries like MikroORM's RequestContext. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@thallesp/nestjs-better-auth",
-	"version": "2.3.1",
+	"version": "2.4.0",
 	"description": "Better Auth for NestJS",
 	"author": "Thalles Passos",
 	"license": "MIT",

--- a/src/auth-module-definition.ts
+++ b/src/auth-module-definition.ts
@@ -6,6 +6,19 @@ export type AuthModuleOptions<A = Auth> = {
 	auth: A;
 	disableTrustedOriginsCors?: boolean;
 	disableBodyParser?: boolean;
+	/**
+	 * When set to `true`, enables raw body parsing and attaches it to `req.rawBody`.
+	 *
+	 * This is useful for webhook signature verification that requires the raw,
+	 * unparsed request body.
+	 *
+	 * **Important:** Since this library disables NestJS's built-in body parser,
+	 * NestJS's `rawBody: true` option in `NestFactory.create()` has no effect.
+	 * Use this option instead.
+	 *
+	 * @default false
+	 */
+	enableRawBodyParser?: boolean;
 	middleware?: (req: Request, res: Response, next: NextFunction) => void;
 };
 

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -137,7 +137,12 @@ export class AuthModule
 
 		if (!this.options.disableBodyParser) {
 			consumer
-				.apply(SkipBodyParsingMiddleware(this.basePath))
+				.apply(
+					SkipBodyParsingMiddleware({
+						basePath: this.basePath,
+						enableRawBodyParser: this.options.enableRawBodyParser,
+					}),
+				)
 				.forRoutes("*path");
 		}
 

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -1,11 +1,58 @@
 import type { NextFunction, Request, Response } from "express";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import * as express from "express";
+import type { OptionsJson } from "body-parser";
+
+export interface SkipBodyParsingMiddlewareOptions {
+	/**
+	 * The base path for Better Auth routes. Body parsing will be skipped for these routes.
+	 * @default "/api/auth"
+	 */
+	basePath?: string;
+	/**
+	 * When set to `true`, enables raw body parsing and attaches it to `req.rawBody`.
+	 *
+	 * This is useful for webhook signature verification that requires the raw,
+	 * unparsed request body.
+	 *
+	 * **Important:** Since this library disables NestJS's built-in body parser,
+	 * NestJS's `rawBody: true` option in `NestFactory.create()` has no effect.
+	 * Use `enableRawBodyParser: true` in `AuthModule.forRoot()` instead.
+	 *
+	 * @default false
+	 */
+	enableRawBodyParser?: boolean;
+}
+
+/**
+ * Raw body parser verify callback.
+ * Same implementation as NestJS's rawBodyParser.
+ * @see https://github.com/nestjs/nest/blob/master/packages/platform-express/adapters/utils/get-body-parser-options.util.ts
+ */
+const rawBodyParser = (
+	req: IncomingMessage & { rawBody?: Buffer },
+	_res: ServerResponse,
+	buffer: Buffer,
+) => {
+	if (Buffer.isBuffer(buffer)) {
+		req.rawBody = buffer;
+	}
+	return true;
+};
 
 /**
  * Factory that returns a Nest middleware which skips body parsing for the
  * configured basePath.
  */
-export function SkipBodyParsingMiddleware(basePath = "/api/auth") {
+export function SkipBodyParsingMiddleware(
+	options: SkipBodyParsingMiddlewareOptions = {},
+) {
+	const { basePath = "/api/auth", enableRawBodyParser = false } = options;
+
+	const jsonParserOptions: OptionsJson = enableRawBodyParser
+		? { verify: rawBodyParser }
+		: {};
+
 	// Return a middleware function compatible with Nest's consumer.apply()
 	// NestJS consumer.apply() accepts plain functions directly
 	return (req: Request, res: Response, next: NextFunction): void => {
@@ -16,7 +63,7 @@ export function SkipBodyParsingMiddleware(basePath = "/api/auth") {
 		}
 
 		// Parse the body as usual
-		express.json()(req, res, (err) => {
+		express.json(jsonParserOptions)(req, res, (err) => {
 			if (err) {
 				next(err);
 				return;

--- a/tests/e2e/options.e2e.test.ts
+++ b/tests/e2e/options.e2e.test.ts
@@ -60,4 +60,42 @@ describe("options e2e", () => {
 			message: MESSAGES.UNKNOWN_EXCEPTION_MESSAGE,
 		});
 	});
+
+	it("should attach rawBody to request when enableRawBodyParser is true", async () => {
+		testSetup = await createTestApp({
+			enableRawBodyParser: true,
+		});
+
+		const httpServer = testSetup.app.getHttpServer();
+
+		const response = await request(httpServer)
+			.post("/test/raw-body")
+			.send({ test: "data" });
+
+		expect(response.status).toBe(201);
+		expect(response.body).toEqual({
+			hasRawBody: true,
+			rawBodyType: "object", // Buffer is typeof "object"
+			isBuffer: true,
+		});
+	});
+
+	it("should not attach rawBody to request when enableRawBodyParser is false", async () => {
+		testSetup = await createTestApp({
+			enableRawBodyParser: false,
+		});
+
+		const httpServer = testSetup.app.getHttpServer();
+
+		const response = await request(httpServer)
+			.post("/test/raw-body")
+			.send({ test: "data" });
+
+		expect(response.status).toBe(201);
+		expect(response.body).toEqual({
+			hasRawBody: false,
+			rawBodyType: null,
+			isBuffer: false,
+		});
+	});
 });

--- a/tests/shared/test-controller.ts
+++ b/tests/shared/test-controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Request } from "@nestjs/common";
+import { Controller, Get, Post, Request } from "@nestjs/common";
 import {
 	OptionalAuth,
 	AllowAnonymous,
@@ -6,6 +6,7 @@ import {
 	OrgRoles,
 } from "../../src/decorators.ts";
 import type { UserSession } from "../../src/auth-guard.ts";
+import type { Request as ExpressRequest } from "express";
 
 // Simple controller with one protected route and one public route
 @Controller("test")
@@ -62,5 +63,15 @@ export class TestController {
 	@Get("org-member-protected")
 	orgMemberProtected(@Request() req: UserSession) {
 		return { user: req.user };
+	}
+
+	@AllowAnonymous()
+	@Post("raw-body")
+	rawBody(@Request() req: ExpressRequest & { rawBody?: Buffer }) {
+		return {
+			hasRawBody: !!req.rawBody,
+			rawBodyType: req.rawBody ? typeof req.rawBody : null,
+			isBuffer: req.rawBody instanceof Buffer,
+		};
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `enableRawBodyParser` option to `AuthModule.forRoot()` that attaches the raw request buffer to `req.rawBody`
- Documents the side effect that NestJS's `rawBody: true` option has no effect when using this library
- Adds tests to verify rawBody functionality

## Why

Since this library requires disabling NestJS's built-in body parser (`bodyParser: false` in `NestFactory.create()`), the `rawBody: true` option has no effect. Users who need access to `req.rawBody` for webhook signature verification were left without a solution.

## Usage

```typescript
AuthModule.forRoot({
  auth,
  enableRawBodyParser: true, // Enables req.rawBody
});
```

Closes #101