### PR TITLE
docs: remove outdated Fastify beta warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ bootstrap();
 > If you need access to `req.rawBody` (e.g., for webhook signature verification), use `bodyParser.rawBody` in `AuthModule.forRoot()` instead.
 > See [Module Options](#module-options) for details.
 
-> [!WARNING]  
-> Currently the library has beta support for Fastify, if you experience any issues with it, please open an issue.
-
 **2. Import AuthModule**
 
 Import the `AuthModule` in your root module:


### PR DESCRIPTION
## Summary
- Remove the Fastify beta support warning block from `README.md`
- Keep Fastify setup instructions intact while eliminating outdated disclaimer
- Update documentation to reflect current Fastify support status

## Testing
- Not run (documentation-only change)
- Verified diff only removes 3 warning lines in `README.md`