### PR TITLE
Fix duplicate Fastify CORS handling for Better Auth trustedOrigins

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Both `bodyParser.json` and `bodyParser.urlencoded` accept parser options plus an
 
 On Fastify, `bodyParser.urlencoded` with `extended: true` uses the optional peer dependency `qs`. Install `qs` in your application if you want nested URL-encoded parsing there.
 
+If you configure `trustedOrigins`, this module also applies Better Auth CORS headers for auth routes. On Fastify, Better Auth routes are mounted through middleware, so app-level `@fastify/cors` does not fully cover them by itself.
+
 ## Route Protection
 
 **Global by default**: An `AuthGuard` is registered globally by this module. All routes are protected unless you explicitly allow access with `@AllowAnonymous()` or mark them as optional with `@OptionalAuth()`.
@@ -580,7 +582,7 @@ The available options are:
 
 | Option                      | Default | Description                                                                                                                                                              |
 | --------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `disableTrustedOriginsCors` | `false` | When set to `true`, disables the automatic CORS configuration for the origins specified in `trustedOrigins`. Use this if you want to handle CORS configuration manually. |
+| `disableTrustedOriginsCors` | `false` | When set to `true`, disables the automatic CORS configuration for the origins specified in `trustedOrigins`. On Fastify, use this only if you want to fully manage Better Auth route CORS yourself. |
 | `bodyParser`                | Re-adds JSON and URL-encoded body parsers | Configure the body parsers re-added by the module after Nest body parsing is disabled. `json` and `urlencoded` accept the parser options object plus `enabled?: boolean`, and `rawBody?: boolean` enables `req.rawBody`. |
 | `disableBodyParser`         | `false` | Deprecated. Use `bodyParser.json.enabled` and `bodyParser.urlencoded.enabled` instead. When set to `true`, disables both parsers unless you explicitly re-enable one in `bodyParser`. |
 | `enableRawBodyParser`       | `false` | Deprecated. Use `bodyParser.rawBody` instead. When set to `true`, enables raw body parsing and attaches the raw buffer to `req.rawBody`. |
@@ -612,6 +614,20 @@ AuthModule.forRoot({
 `bodyParser.rawBody` enables `req.rawBody` support, while `bodyParser.json` and `bodyParser.urlencoded` configure the corresponding parser behavior for the active adapter.
 
 If you use Fastify with `bodyParser.urlencoded({ extended: true })`, install the optional peer dependency `qs` to enable nested form parsing.
+
+### CORS on Fastify
+
+If your Better Auth config sets `trustedOrigins`, this module applies CORS to Better Auth routes automatically.
+
+On Fastify, Better Auth routes are served through middleware internally. Because of that:
+
+- app-level `@fastify/cors` does not fully apply to Better Auth routes on its own
+- this module applies Better Auth route CORS from `trustedOrigins`
+- if `@fastify/cors` is already registered, this module skips duplicate Fastify CORS registration and logs a warning once
+
+This Fastify fallback only supports array-based `trustedOrigins`. Function-based `trustedOrigins` remain unsupported unless you set `disableTrustedOriginsCors: true` and manage Better Auth route CORS manually.
+
+Set `disableTrustedOriginsCors: true` only if you want to fully manage Better Auth route CORS yourself.
 
 ### Using Custom Middleware
 

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -28,6 +28,7 @@ import {
 	SkipBodyParsingMiddleware,
 	getNodeRequest,
 	getNodeResponse,
+	handleFastifyTrustedOriginsCors,
 	matchesBasePath,
 	resolveBodyParserOptions,
 } from "./middlewares.ts";
@@ -130,11 +131,32 @@ export class AuthModule
 		const isNotFunctionBased = trustedOrigins && Array.isArray(trustedOrigins);
 
 		if (!this.options.disableTrustedOriginsCors && isNotFunctionBased) {
-			this.adapter.httpAdapter.enableCors({
-				origin: trustedOrigins,
-				methods: ["GET", "POST", "PUT", "DELETE"],
-				credentials: true,
-			});
+			if (adapterType === "fastify") {
+				const fastifyInstance = this.adapter.httpAdapter.getInstance<{
+					hasRequestDecorator?: (name: string) => boolean;
+				}>();
+				const hasFastifyCorsRegistered =
+					fastifyInstance?.hasRequestDecorator?.("corsPreflightEnabled") ??
+					false;
+
+				if (hasFastifyCorsRegistered) {
+					this.logger.warn(
+						"Detected an existing @fastify/cors registration. Skipping automatic Fastify CORS registration for Better Auth trustedOrigins to avoid duplicate plugin registration. Better Auth routes will still apply CORS from trustedOrigins. Set disableTrustedOriginsCors: true if you want to fully manage Better Auth CORS yourself.",
+					);
+				} else {
+					this.adapter.httpAdapter.enableCors({
+						origin: trustedOrigins,
+						methods: ["GET", "POST", "PUT", "DELETE"],
+						credentials: true,
+					});
+				}
+			} else {
+				this.adapter.httpAdapter.enableCors({
+					origin: trustedOrigins,
+					methods: ["GET", "POST", "PUT", "DELETE"],
+					credentials: true,
+				});
+			}
 		} else if (
 			trustedOrigins &&
 			!this.options.disableTrustedOriginsCors &&
@@ -176,6 +198,17 @@ export class AuthModule
 			(req: Request, res: Response, next: () => void) => {
 				if (!matchesBasePath(req, this.basePath)) {
 					next();
+					return;
+				}
+
+				if (
+					adapterType === "fastify" &&
+					!this.options.disableTrustedOriginsCors &&
+					isNotFunctionBased &&
+					handleFastifyTrustedOriginsCors(req, res, {
+						trustedOrigins,
+					})
+				) {
 					return;
 				}
 

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -43,6 +43,17 @@ type ResponseLike = Response & {
 	raw?: Response;
 };
 
+type NodeRequestLike = IncomingMessage & {
+	method?: string;
+	headers: IncomingMessage["headers"];
+};
+
+type NodeResponseLike = ServerResponse<IncomingMessage> & {
+	getHeader(name: string): number | string | string[] | undefined;
+	setHeader(name: string, value: number | string | readonly string[]): this;
+	statusCode: number;
+};
+
 export type ResolvedJsonBodyParserOptions = JsonBodyParserOptions & {
 	enabled: boolean;
 	rawBody: boolean;
@@ -110,6 +121,102 @@ export function matchesBasePath(req: RequestLike, basePath: string) {
 	const requestPath = getRequestPath(req);
 
 	return requestPath === basePath || requestPath.startsWith(`${basePath}/`);
+}
+
+function getHeaderValue(header: string | string[] | undefined) {
+	if (Array.isArray(header)) {
+		return header.join(", ");
+	}
+
+	return header;
+}
+
+function appendVaryHeader(res: NodeResponseLike, value: string) {
+	const currentHeader = res.getHeader("Vary");
+	const currentValue =
+		typeof currentHeader === "number"
+			? String(currentHeader)
+			: Array.isArray(currentHeader)
+				? currentHeader.join(", ")
+				: currentHeader;
+
+	const varyValues = new Set(
+		currentValue
+			?.split(",")
+			.map((item) => item.trim())
+			.filter(Boolean) ?? [],
+	);
+	varyValues.add(value);
+
+	res.setHeader("Vary", Array.from(varyValues).join(", "));
+}
+
+function escapeRegex(pattern: string) {
+	return pattern.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function matchesOriginPattern(origin: string, pattern: string) {
+	if (pattern === "*") return true;
+
+	const regex = new RegExp(
+		`^${pattern.split("*").map(escapeRegex).join(".*")}$`,
+	);
+	return regex.test(origin);
+}
+
+function isAllowedOrigin(origin: string, trustedOrigins: string[]) {
+	return trustedOrigins.some((trustedOrigin) =>
+		matchesOriginPattern(origin, trustedOrigin),
+	);
+}
+
+export interface FastifyTrustedOriginsCorsOptions {
+	trustedOrigins: string[];
+}
+
+export function handleFastifyTrustedOriginsCors(
+	req: RequestLike,
+	res: ResponseLike,
+	options: FastifyTrustedOriginsCorsOptions,
+) {
+	const nodeReq = getNodeRequest(req) as NodeRequestLike;
+	const nodeRes = getNodeResponse(res) as NodeResponseLike;
+	const origin = getHeaderValue(nodeReq.headers.origin);
+
+	if (!origin || !isAllowedOrigin(origin, options.trustedOrigins)) {
+		return false;
+	}
+
+	nodeRes.setHeader("Access-Control-Allow-Origin", origin);
+	nodeRes.setHeader("Access-Control-Allow-Credentials", "true");
+	appendVaryHeader(nodeRes, "Origin");
+
+	if (nodeReq.method?.toUpperCase() !== "OPTIONS") {
+		return false;
+	}
+
+	const requestMethod = getHeaderValue(
+		nodeReq.headers["access-control-request-method"],
+	);
+	const requestHeaders = getHeaderValue(
+		nodeReq.headers["access-control-request-headers"],
+	);
+
+	nodeRes.setHeader(
+		"Access-Control-Allow-Methods",
+		requestMethod ?? "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS",
+	);
+
+	if (requestHeaders) {
+		nodeRes.setHeader("Access-Control-Allow-Headers", requestHeaders);
+		appendVaryHeader(nodeRes, "Access-Control-Request-Headers");
+	}
+
+	nodeRes.statusCode = 204;
+	nodeRes.setHeader("Content-Length", "0");
+	nodeRes.end();
+
+	return true;
 }
 
 /**

--- a/tests/e2e/cors.e2e.test.ts
+++ b/tests/e2e/cors.e2e.test.ts
@@ -1,0 +1,160 @@
+import { Logger } from "@nestjs/common";
+import cors from "@fastify/cors";
+import request from "supertest";
+import { vi } from "vitest";
+import { createTestApp, type TestAppSetup } from "../shared/test-utils.ts";
+
+const TRUSTED_ORIGIN = "http://localhost:3000";
+const isFastify = process.env.TEST_HTTP_ADAPTER === "fastify";
+const fastifyOnly = isFastify ? it : it.skip;
+
+describe("cors e2e", () => {
+	let testSetup: TestAppSetup | undefined;
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+
+		if (!testSetup) return;
+
+		await testSetup.app.close();
+		testSetup = undefined;
+	});
+
+	it("should apply trustedOrigins CORS headers on Better Auth routes", async () => {
+		testSetup = await createTestApp(undefined, false, {
+			authOptions: {
+				trustedOrigins: [TRUSTED_ORIGIN],
+			},
+		});
+
+		const httpServer = testSetup.app.getHttpServer();
+
+		const optionsResponse = await request(httpServer)
+			.options("/api/auth/sign-in/email")
+			.set("Origin", TRUSTED_ORIGIN)
+			.set("Access-Control-Request-Method", "POST")
+			.set("Access-Control-Request-Headers", "content-type, stripe-signature");
+
+		expect(optionsResponse.status).toBe(204);
+		expect(optionsResponse.headers["access-control-allow-origin"]).toBe(
+			TRUSTED_ORIGIN,
+		);
+		expect(optionsResponse.headers["access-control-allow-credentials"]).toBe(
+			"true",
+		);
+
+		if (isFastify) {
+			expect(optionsResponse.headers["access-control-allow-headers"]).toBe(
+				"content-type, stripe-signature",
+			);
+		}
+
+		const okResponse = await request(httpServer)
+			.get("/api/auth/ok")
+			.set("Origin", TRUSTED_ORIGIN);
+
+		expect(okResponse.status).toBe(200);
+		expect(okResponse.headers["access-control-allow-origin"]).toBe(
+			TRUSTED_ORIGIN,
+		);
+		expect(okResponse.headers["access-control-allow-credentials"]).toBe("true");
+	});
+
+	fastifyOnly(
+		"should warn and skip duplicate Fastify CORS registration when @fastify/cors is already registered",
+		async () => {
+			const warnSpy = vi
+				.spyOn(Logger.prototype, "warn")
+				.mockImplementation(() => undefined);
+
+			testSetup = await createTestApp(undefined, false, {
+				authOptions: {
+					trustedOrigins: [TRUSTED_ORIGIN],
+				},
+				configureAdapter: async (adapter) => {
+					await adapter.register(cors, {
+						origin: [TRUSTED_ORIGIN],
+						credentials: true,
+					});
+				},
+			});
+
+			const warningCalls = warnSpy.mock.calls.filter(([message]) =>
+				String(message).includes(
+					"Detected an existing @fastify/cors registration.",
+				),
+			);
+
+			expect(warningCalls).toHaveLength(1);
+
+			const httpServer = testSetup.app.getHttpServer();
+			const optionsResponse = await request(httpServer)
+				.options("/api/auth/sign-in/email")
+				.set("Origin", TRUSTED_ORIGIN)
+				.set("Access-Control-Request-Method", "POST")
+				.set("Access-Control-Request-Headers", "content-type");
+
+			expect(optionsResponse.status).toBe(204);
+			expect(optionsResponse.headers["access-control-allow-origin"]).toBe(
+				TRUSTED_ORIGIN,
+			);
+
+			const okResponse = await request(httpServer)
+				.get("/api/auth/ok")
+				.set("Origin", TRUSTED_ORIGIN);
+
+			expect(okResponse.status).toBe(200);
+			expect(okResponse.headers["access-control-allow-origin"]).toBe(
+				TRUSTED_ORIGIN,
+			);
+			expect(okResponse.headers["access-control-allow-credentials"]).toBe(
+				"true",
+			);
+		},
+	);
+
+	fastifyOnly(
+		"should not add Better Auth route CORS on Fastify when disableTrustedOriginsCors is true",
+		async () => {
+			testSetup = await createTestApp(
+				{
+					disableTrustedOriginsCors: true,
+				},
+				false,
+				{
+					authOptions: {
+						trustedOrigins: [TRUSTED_ORIGIN],
+					},
+					configureAdapter: async (adapter) => {
+						await adapter.register(cors, {
+							origin: [TRUSTED_ORIGIN],
+							credentials: true,
+						});
+					},
+				},
+			);
+
+			const httpServer = testSetup.app.getHttpServer();
+			const optionsResponse = await request(httpServer)
+				.options("/api/auth/sign-in/email")
+				.set("Origin", TRUSTED_ORIGIN)
+				.set("Access-Control-Request-Method", "POST")
+				.set("Access-Control-Request-Headers", "content-type");
+
+			expect(optionsResponse.status).toBe(204);
+			expect(optionsResponse.headers["access-control-allow-origin"]).toBe(
+				TRUSTED_ORIGIN,
+			);
+
+			const okResponse = await request(httpServer)
+				.get("/api/auth/ok")
+				.set("Origin", TRUSTED_ORIGIN);
+
+			expect(okResponse.status).toBe(200);
+			expect(okResponse.headers["access-control-allow-origin"]).toBeUndefined();
+			expect(
+				okResponse.headers["access-control-allow-credentials"],
+			).toBeUndefined();
+		},
+	);
+});

--- a/tests/shared/test-utils.ts
+++ b/tests/shared/test-utils.ts
@@ -15,8 +15,11 @@ import { adminAc, userAc } from "better-auth/plugins/admin/access";
 import { type OPTIONS_TYPE } from "../../src/auth-module-definition.ts";
 import { createTestHttpAdapter, initTestApplication } from "./http-adapter.ts";
 
+type BetterAuthOptions = Parameters<typeof betterAuth>[0];
+type TestHttpAdapter = ReturnType<typeof createTestHttpAdapter>;
+
 // Create Better Auth instance factory
-export function createTestAuth() {
+export function createTestAuth(authOptions?: Partial<BetterAuthOptions>) {
 	return betterAuth({
 		basePath: "/api/auth",
 		emailAndPassword: {
@@ -32,6 +35,7 @@ export function createTestAuth() {
 				},
 			}),
 		],
+		...authOptions,
 	});
 }
 
@@ -72,13 +76,19 @@ export function createTestAppModule(
 export interface TestAppOptions {
 	globalPrefix?: string;
 	initialize?: boolean;
+	authOptions?: Partial<BetterAuthOptions>;
+	configureAdapter?: (adapter: TestHttpAdapter) => Promise<void> | void;
 }
 
 export async function createTestNestApplication(
 	moduleRef: TestingModule,
 	appOptions?: TestAppOptions,
 ) {
-	const app = moduleRef.createNestApplication(createTestHttpAdapter(), {
+	const adapter = createTestHttpAdapter();
+
+	await appOptions?.configureAdapter?.(adapter);
+
+	const app = moduleRef.createNestApplication(adapter, {
 		bodyParser: false,
 	});
 
@@ -98,7 +108,7 @@ export async function createTestApp(
 	async = false,
 	appOptions?: TestAppOptions,
 ) {
-	const auth = createTestAuth();
+	const auth = createTestAuth(appOptions?.authOptions);
 	const AppModule = createTestAppModule(async, auth, options);
 
 	const moduleRef = await Test.createTestingModule({


### PR DESCRIPTION
## Summary
- Fixes Fastify CORS duplication when `trustedOrigins` is configured by detecting existing `@fastify/cors` registration and skipping duplicate plugin setup.
- Adds Better Auth route-level CORS handling for Fastify middleware-mounted auth routes, including preflight (`OPTIONS`) responses and origin matching (with wildcard support).
- Preserves existing behavior for non-Fastify adapters and keeps `disableTrustedOriginsCors` as the opt-out for fully manual CORS management.
- Updates README with Fastify-specific CORS behavior, caveats, and configuration guidance.
- Expands test utilities to support custom Better Auth options and adapter pre-configuration in e2e scenarios.

## Testing
- Added e2e test: applies `trustedOrigins` CORS headers on Better Auth routes, including preflight checks.
- Added Fastify-only e2e test: verifies warning is logged once and duplicate Fastify CORS registration is skipped when `@fastify/cors` is already registered.
- Added Fastify-only e2e test: verifies Better Auth route CORS headers are not added when `disableTrustedOriginsCors: true`.
- Local test execution: Not run.