### PR TITLE
feat: add support for better-auth database hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,89 @@ import { auth } from "./auth";
 export class AppModule {}
 ```
 
+### Database Hook Decorators
+
+> [!IMPORTANT]
+> To use `@DatabaseHook`, `@BeforeCreate`, `@AfterCreate`, `@BeforeUpdate`, `@AfterUpdate`, `@BeforeDelete`, `@AfterDelete`, set `databaseHooks: {}` (empty object) in your `betterAuth(...)` config.
+
+Database hooks let you hook into the lifecycle of core database operations (create, update, delete) for Better Auth models (`user`, `session`, `account`, `verification`).
+
+Minimal Better Auth setup with database hooks enabled:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  // other better-auth options...
+  databaseHooks: {}, // empty object is the minimum required
+});
+```
+
+Create database hooks that integrate with NestJS's dependency injection:
+
+```ts title="hooks/user-create.hook.ts"
+import { Injectable } from "@nestjs/common";
+import {
+  DatabaseHook,
+  BeforeCreate,
+  AfterCreate,
+} from "@thallesp/nestjs-better-auth";
+import { EmailService } from "./email.service";
+
+@DatabaseHook()
+@Injectable()
+export class UserCreateHook {
+  constructor(private readonly emailService: EmailService) {}
+
+  @BeforeCreate("user")
+  async beforeUserCreate(user) {
+    return {
+      data: {
+        ...user,
+        firstName: user.name.split(" ")[0],
+        lastName: user.name.split(" ")[1],
+      },
+    };
+  }
+
+  @AfterCreate("user")
+  async afterUserCreate(user) {
+    await this.emailService.sendWelcomeEmail(user.email);
+  }
+}
+```
+
+Register your database hooks in a module:
+
+```ts title="app.module.ts"
+import { Module } from "@nestjs/common";
+import { AuthModule } from "@thallesp/nestjs-better-auth";
+import { UserCreateHook } from "./hooks/user-create.hook";
+import { EmailService } from "./email.service";
+import { auth } from "./auth";
+
+@Module({
+  imports: [AuthModule.forRoot({ auth })],
+  providers: [UserCreateHook, EmailService],
+})
+export class AppModule {}
+```
+
+Available method decorators:
+
+| Decorator | Description |
+|-----------|-------------|
+| `@BeforeCreate(model)` | Runs before a record is created |
+| `@AfterCreate(model)` | Runs after a record is created |
+| `@BeforeUpdate(model)` | Runs before a record is updated |
+| `@AfterUpdate(model)` | Runs after a record is updated |
+| `@BeforeDelete(model)` | Runs before a record is deleted |
+| `@AfterDelete(model)` | Runs after a record is deleted |
+
+Where `model` is one of: `"user"`, `"session"`, `"account"`, `"verification"`.
+
+`before` hooks can return `false` to abort the operation, or `{ data: ... }` to modify the data before it's written. `after` hooks are for side effects only.
+
 ## AuthService
 
 The `AuthService` is automatically provided by the `AuthModule` and can be injected into your controllers to access the Better Auth instance and its API endpoints.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@thallesp/nestjs-better-auth",
-	"version": "2.5.4",
+	"version": "2.6.0",
 	"description": "Better Auth for NestJS",
 	"author": "Thalles Passos",
 	"license": "MIT",

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -163,7 +163,7 @@ export class AuthModule
 
 		if (hasDatabaseHookProviders && !databaseHooksConfigured)
 			throw new Error(
-				"Detected @DatabaseHook providers but Better Auth 'databaseHooks' is not configured. Add 'databaseHooks: {}' to your betterAuth(...) options (it can be empty).",
+				"Detected @DatabaseHook providers but Better Auth 'databaseHooks' is not configured. Add an empty 'databaseHooks: {}' object to your betterAuth(...) options.",
 			);
 
 		if (!hasDatabaseHookProviders) return;

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -157,9 +157,16 @@ export class AuthModule
 					metatype && Reflect.getMetadata(DATABASE_HOOK_KEY, metatype),
 			);
 
-		if (databaseHookProviders.length === 0) return;
+		const hasDatabaseHookProviders = databaseHookProviders.length > 0;
+		const databaseHooksConfigured =
+			typeof this.options.auth?.options?.databaseHooks === "object";
 
-		this.options.auth.options.databaseHooks ??= {};
+		if (hasDatabaseHookProviders && !databaseHooksConfigured)
+			throw new Error(
+				"Detected @DatabaseHook providers but Better Auth 'databaseHooks' is not configured. Add 'databaseHooks: {}' to your betterAuth(...) options (it can be empty).",
+			);
+
+		if (!hasDatabaseHookProviders) return;
 
 		for (const provider of databaseHookProviders) {
 			const providerPrototype = Object.getPrototypeOf(provider.instance);
@@ -319,6 +326,8 @@ export class AuthModule
 		providerMethod: (...args: unknown[]) => unknown,
 		providerClass: { new (...args: unknown[]): unknown },
 	) {
+		if (!this.options.auth.options.databaseHooks) return;
+
 		for (const { metadataKey, hookType } of DATABASE_HOOKS) {
 			if (!Reflect.hasMetadata(metadataKey, providerMethod)) continue;
 

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -157,22 +157,9 @@ export class AuthModule
 					metatype && Reflect.getMetadata(DATABASE_HOOK_KEY, metatype),
 			);
 
-		const hasDatabaseHookProviders = databaseHookProviders.length > 0;
-		const databaseHooksConfigured =
-			typeof this.options.auth?.options?.databaseHooks === "object";
+		if (databaseHookProviders.length === 0) return;
 
-		/**
-		 * TODO: This check might not be necessary for database hooks since we build the
-		 * databaseHooks object ourselves (unlike regular hooks which need createAuthMiddleware).
-		 * Try commenting this block out to see if it still works without requiring
-		 * `databaseHooks: {}` in the betterAuth config.
-		 */
-		if (hasDatabaseHookProviders && !databaseHooksConfigured)
-			throw new Error(
-				"Detected @DatabaseHook providers but Better Auth 'databaseHooks' are not configured. Add 'databaseHooks: {}' to your betterAuth(...) options.",
-			);
-
-		if (!hasDatabaseHookProviders) return;
+		this.options.auth.options.databaseHooks ??= {};
 
 		for (const provider of databaseHookProviders) {
 			const providerPrototype = Object.getPrototypeOf(provider.instance);
@@ -332,8 +319,6 @@ export class AuthModule
 		providerMethod: (...args: unknown[]) => unknown,
 		providerClass: { new (...args: unknown[]): unknown },
 	) {
-		if (!this.options.auth.options.databaseHooks) return;
-
 		for (const { metadataKey, hookType } of DATABASE_HOOKS) {
 			if (!Reflect.hasMetadata(metadataKey, providerMethod)) continue;
 

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -35,7 +35,15 @@ import {
 	matchesBasePath,
 	resolveBodyParserOptions,
 } from "./middlewares.ts";
-import { AFTER_HOOK_KEY, BEFORE_HOOK_KEY, HOOK_KEY } from "./symbols.ts";
+import {
+	AFTER_DATABASE_HOOK_KEY,
+	AFTER_HOOK_KEY,
+	BEFORE_DATABASE_HOOK_KEY,
+	BEFORE_HOOK_KEY,
+	DATABASE_HOOK_KEY,
+	HOOK_KEY,
+} from "./symbols.ts";
+import type { DatabaseHookModel, DatabaseHookOperation } from "./decorators.ts";
 import { AuthGuard } from "./auth-guard.ts";
 import { APP_GUARD } from "@nestjs/core";
 import { normalizePath } from "@nestjs/common/utils/shared.utils.js";
@@ -44,6 +52,11 @@ import { mapToExcludeRoute } from "@nestjs/core/middleware/utils.js";
 const HOOKS = [
 	{ metadataKey: BEFORE_HOOK_KEY, hookType: "before" as const },
 	{ metadataKey: AFTER_HOOK_KEY, hookType: "after" as const },
+];
+
+const DATABASE_HOOKS = [
+	{ metadataKey: BEFORE_DATABASE_HOOK_KEY, hookType: "before" as const },
+	{ metadataKey: AFTER_DATABASE_HOOK_KEY, hookType: "after" as const },
 ];
 
 type AdapterRequest = ExpressRequest & {
@@ -108,13 +121,13 @@ export class AuthModule
 	}
 
 	onModuleInit(): void {
-		const providers = this.discoveryService
+		const hookProviders = this.discoveryService
 			.getProviders()
 			.filter(
 				({ metatype }) => metatype && Reflect.getMetadata(HOOK_KEY, metatype),
 			);
 
-		const hasHookProviders = providers.length > 0;
+		const hasHookProviders = hookProviders.length > 0;
 		const hooksConfigured =
 			typeof this.options.auth?.options?.hooks === "object";
 
@@ -123,15 +136,51 @@ export class AuthModule
 				"Detected @Hook providers but Better Auth 'hooks' are not configured. Add 'hooks: {}' to your betterAuth(...) options.",
 			);
 
-		if (!hooksConfigured) return;
+		if (hooksConfigured) {
+			for (const provider of hookProviders) {
+				const providerPrototype = Object.getPrototypeOf(provider.instance);
+				const methods =
+					this.metadataScanner.getAllMethodNames(providerPrototype);
 
-		for (const provider of providers) {
+				for (const method of methods) {
+					const providerMethod = providerPrototype[method];
+					this.setupHooks(providerMethod, provider.instance);
+				}
+			}
+		}
+
+		// Database hooks discovery
+		const databaseHookProviders = this.discoveryService
+			.getProviders()
+			.filter(
+				({ metatype }) =>
+					metatype && Reflect.getMetadata(DATABASE_HOOK_KEY, metatype),
+			);
+
+		const hasDatabaseHookProviders = databaseHookProviders.length > 0;
+		const databaseHooksConfigured =
+			typeof this.options.auth?.options?.databaseHooks === "object";
+
+		/**
+		 * TODO: This check might not be necessary for database hooks since we build the
+		 * databaseHooks object ourselves (unlike regular hooks which need createAuthMiddleware).
+		 * Try commenting this block out to see if it still works without requiring
+		 * `databaseHooks: {}` in the betterAuth config.
+		 */
+		if (hasDatabaseHookProviders && !databaseHooksConfigured)
+			throw new Error(
+				"Detected @DatabaseHook providers but Better Auth 'databaseHooks' are not configured. Add 'databaseHooks: {}' to your betterAuth(...) options.",
+			);
+
+		if (!hasDatabaseHookProviders) return;
+
+		for (const provider of databaseHookProviders) {
 			const providerPrototype = Object.getPrototypeOf(provider.instance);
 			const methods = this.metadataScanner.getAllMethodNames(providerPrototype);
 
 			for (const method of methods) {
 				const providerMethod = providerPrototype[method];
-				this.setupHooks(providerMethod, provider.instance);
+				this.setupDatabaseHooks(providerMethod, provider.instance);
 			}
 		}
 	}
@@ -276,6 +325,38 @@ export class AuthModule
 					await providerMethod.apply(providerClass, [ctx]);
 				},
 			);
+		}
+	}
+
+	private setupDatabaseHooks(
+		providerMethod: (...args: unknown[]) => unknown,
+		providerClass: { new (...args: unknown[]): unknown },
+	) {
+		if (!this.options.auth.options.databaseHooks) return;
+
+		for (const { metadataKey, hookType } of DATABASE_HOOKS) {
+			if (!Reflect.hasMetadata(metadataKey, providerMethod)) continue;
+
+			const { model, operation } = Reflect.getMetadata(
+				metadataKey,
+				providerMethod,
+			) as { model: DatabaseHookModel; operation: DatabaseHookOperation };
+
+			const databaseHooks = this.options.auth.options.databaseHooks;
+
+			// Ensure the nested structure exists: databaseHooks[model][operation]
+			databaseHooks[model] ??= {};
+			databaseHooks[model][operation] ??= {};
+
+			const originalHook = databaseHooks[model][operation][hookType];
+			databaseHooks[model][operation][hookType] = async (
+				...args: unknown[]
+			) => {
+				if (originalHook) {
+					await originalHook(...args);
+				}
+				return providerMethod.apply(providerClass, args);
+			};
 		}
 	}
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,7 +1,14 @@
 import { SetMetadata, createParamDecorator } from "@nestjs/common";
 import type { CustomDecorator, ExecutionContext } from "@nestjs/common";
 import type { createAuthMiddleware } from "better-auth/api";
-import { AFTER_HOOK_KEY, BEFORE_HOOK_KEY, HOOK_KEY } from "./symbols.ts";
+import {
+	AFTER_DATABASE_HOOK_KEY,
+	AFTER_HOOK_KEY,
+	BEFORE_DATABASE_HOOK_KEY,
+	BEFORE_HOOK_KEY,
+	DATABASE_HOOK_KEY,
+	HOOK_KEY,
+} from "./symbols.ts";
 import { getRequestFromContext } from "./utils.ts";
 
 /**
@@ -185,3 +192,66 @@ export const AfterHook = (path?: `/${string}`): CustomDecorator<symbol> =>
  * Must be applied to classes that use BeforeHook or AfterHook decorators.
  */
 export const Hook = (): ClassDecorator => SetMetadata(HOOK_KEY, true);
+
+/**
+ * The models that support database hooks in Better Auth.
+ */
+export type DatabaseHookModel = "user" | "session" | "account" | "verification";
+
+/**
+ * The operations that support database hooks in Better Auth.
+ */
+export type DatabaseHookOperation = "create" | "update" | "delete";
+
+/**
+ * Class decorator that marks a provider as containing database hook methods.
+ * Must be applied to classes that use BeforeDatabaseHook or AfterDatabaseHook decorators.
+ */
+export const DatabaseHook = (): ClassDecorator =>
+	SetMetadata(DATABASE_HOOK_KEY, true);
+
+/**
+ * Registers a method to be executed before a database operation on a specific model.
+ * @param model - The model to hook into (user, session, account, verification)
+ * @param operation - The operation to hook into (create, update, delete)
+ *
+ * @example
+ * ```ts
+ * @DatabaseHook()
+ * @Injectable()
+ * class MyHooks {
+ *   @BeforeDatabaseHook("user", "create")
+ *   async beforeUserCreate(user: User, ctx: GenericEndpointContext | null) {
+ *     return { data: { ...user, name: user.name.toUpperCase() } };
+ *   }
+ * }
+ * ```
+ */
+export const BeforeDatabaseHook = (
+	model: DatabaseHookModel,
+	operation: DatabaseHookOperation,
+): CustomDecorator<symbol> =>
+	SetMetadata(BEFORE_DATABASE_HOOK_KEY, { model, operation });
+
+/**
+ * Registers a method to be executed after a database operation on a specific model.
+ * @param model - The model to hook into (user, session, account, verification)
+ * @param operation - The operation to hook into (create, update, delete)
+ *
+ * @example
+ * ```ts
+ * @DatabaseHook()
+ * @Injectable()
+ * class MyHooks {
+ *   @AfterDatabaseHook("user", "create")
+ *   async afterUserCreate(user: User, ctx: GenericEndpointContext | null) {
+ *     await this.emailService.sendWelcomeEmail(user.email);
+ *   }
+ * }
+ * ```
+ */
+export const AfterDatabaseHook = (
+	model: DatabaseHookModel,
+	operation: DatabaseHookOperation,
+): CustomDecorator<symbol> =>
+	SetMetadata(AFTER_DATABASE_HOOK_KEY, { model, operation });

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -205,53 +205,61 @@ export type DatabaseHookOperation = "create" | "update" | "delete";
 
 /**
  * Class decorator that marks a provider as containing database hook methods.
- * Must be applied to classes that use BeforeDatabaseHook or AfterDatabaseHook decorators.
+ * Must be applied to classes that use database hook method decorators.
  */
 export const DatabaseHook = (): ClassDecorator =>
 	SetMetadata(DATABASE_HOOK_KEY, true);
 
 /**
- * Registers a method to be executed before a database operation on a specific model.
+ * Registers a method to be executed before a record is created.
  * @param model - The model to hook into (user, session, account, verification)
- * @param operation - The operation to hook into (create, update, delete)
- *
- * @example
- * ```ts
- * @DatabaseHook()
- * @Injectable()
- * class MyHooks {
- *   @BeforeDatabaseHook("user", "create")
- *   async beforeUserCreate(user: User, ctx: GenericEndpointContext | null) {
- *     return { data: { ...user, name: user.name.toUpperCase() } };
- *   }
- * }
- * ```
  */
-export const BeforeDatabaseHook = (
+export const BeforeCreate = (
 	model: DatabaseHookModel,
-	operation: DatabaseHookOperation,
 ): CustomDecorator<symbol> =>
-	SetMetadata(BEFORE_DATABASE_HOOK_KEY, { model, operation });
+	SetMetadata(BEFORE_DATABASE_HOOK_KEY, { model, operation: "create" });
 
 /**
- * Registers a method to be executed after a database operation on a specific model.
+ * Registers a method to be executed after a record is created.
  * @param model - The model to hook into (user, session, account, verification)
- * @param operation - The operation to hook into (create, update, delete)
- *
- * @example
- * ```ts
- * @DatabaseHook()
- * @Injectable()
- * class MyHooks {
- *   @AfterDatabaseHook("user", "create")
- *   async afterUserCreate(user: User, ctx: GenericEndpointContext | null) {
- *     await this.emailService.sendWelcomeEmail(user.email);
- *   }
- * }
- * ```
  */
-export const AfterDatabaseHook = (
+export const AfterCreate = (
 	model: DatabaseHookModel,
-	operation: DatabaseHookOperation,
 ): CustomDecorator<symbol> =>
-	SetMetadata(AFTER_DATABASE_HOOK_KEY, { model, operation });
+	SetMetadata(AFTER_DATABASE_HOOK_KEY, { model, operation: "create" });
+
+/**
+ * Registers a method to be executed before a record is updated.
+ * @param model - The model to hook into (user, session, account, verification)
+ */
+export const BeforeUpdate = (
+	model: DatabaseHookModel,
+): CustomDecorator<symbol> =>
+	SetMetadata(BEFORE_DATABASE_HOOK_KEY, { model, operation: "update" });
+
+/**
+ * Registers a method to be executed after a record is updated.
+ * @param model - The model to hook into (user, session, account, verification)
+ */
+export const AfterUpdate = (
+	model: DatabaseHookModel,
+): CustomDecorator<symbol> =>
+	SetMetadata(AFTER_DATABASE_HOOK_KEY, { model, operation: "update" });
+
+/**
+ * Registers a method to be executed before a record is deleted.
+ * @param model - The model to hook into (user, session, account, verification)
+ */
+export const BeforeDelete = (
+	model: DatabaseHookModel,
+): CustomDecorator<symbol> =>
+	SetMetadata(BEFORE_DATABASE_HOOK_KEY, { model, operation: "delete" });
+
+/**
+ * Registers a method to be executed after a record is deleted.
+ * @param model - The model to hook into (user, session, account, verification)
+ */
+export const AfterDelete = (
+	model: DatabaseHookModel,
+): CustomDecorator<symbol> =>
+	SetMetadata(AFTER_DATABASE_HOOK_KEY, { model, operation: "delete" });

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -2,3 +2,9 @@ export const BEFORE_HOOK_KEY = Symbol("BEFORE_HOOK") as symbol;
 export const AFTER_HOOK_KEY = Symbol("AFTER_HOOK") as symbol;
 export const HOOK_KEY = Symbol("HOOK") as symbol;
 export const AUTH_MODULE_OPTIONS_KEY = Symbol("AUTH_MODULE_OPTIONS") as symbol;
+
+export const DATABASE_HOOK_KEY = Symbol("DATABASE_HOOK") as symbol;
+export const BEFORE_DATABASE_HOOK_KEY = Symbol(
+	"BEFORE_DATABASE_HOOK",
+) as symbol;
+export const AFTER_DATABASE_HOOK_KEY = Symbol("AFTER_DATABASE_HOOK") as symbol;

--- a/tests/e2e/database-hooks.e2e.test.ts
+++ b/tests/e2e/database-hooks.e2e.test.ts
@@ -1,0 +1,197 @@
+import "reflect-metadata";
+import request from "supertest";
+import { faker } from "@faker-js/faker";
+import { Module, Injectable, type INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { betterAuth } from "better-auth";
+import { bearer } from "better-auth/plugins/bearer";
+import {
+	AuthModule,
+	DatabaseHook,
+	BeforeCreate,
+	AfterCreate,
+	BeforeUpdate,
+	AfterUpdate,
+	BeforeDelete,
+	AfterDelete,
+} from "../../src/index.ts";
+import { createTestNestApplication } from "../shared/test-utils.ts";
+
+@Injectable()
+class DatabaseHookTrackerService {
+	calls: { hook: string; model: string; operation: string }[] = [];
+
+	track(hook: string, model: string, operation: string) {
+		this.calls.push({ hook, model, operation });
+	}
+
+	getCalls(hook: string, model: string, operation: string) {
+		return this.calls.filter(
+			(c) => c.hook === hook && c.model === model && c.operation === operation,
+		);
+	}
+}
+
+@DatabaseHook()
+@Injectable()
+class UserDatabaseHook {
+	constructor(private readonly tracker: DatabaseHookTrackerService) {}
+
+	@BeforeCreate("user")
+	async beforeCreate() {
+		this.tracker.track("before", "user", "create");
+	}
+
+	@AfterCreate("user")
+	async afterCreate() {
+		this.tracker.track("after", "user", "create");
+	}
+}
+
+@DatabaseHook()
+@Injectable()
+class SessionDatabaseHook {
+	constructor(private readonly tracker: DatabaseHookTrackerService) {}
+
+	@AfterCreate("session")
+	async afterCreate() {
+		this.tracker.track("after", "session", "create");
+	}
+}
+
+describe("database hooks e2e", () => {
+	let app: INestApplication;
+
+	beforeAll(async () => {
+		const auth = betterAuth({
+			basePath: "/api/auth",
+			emailAndPassword: { enabled: true },
+			plugins: [bearer()],
+			databaseHooks: {},
+		});
+
+		@Module({
+			imports: [AuthModule.forRoot({ auth })],
+			providers: [
+				DatabaseHookTrackerService,
+				UserDatabaseHook,
+				SessionDatabaseHook,
+			],
+		})
+		class AppModule {}
+
+		const moduleRef = await Test.createTestingModule({
+			imports: [AppModule],
+		}).compile();
+
+		app = await createTestNestApplication(moduleRef);
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	it("should call @BeforeCreate('user') on sign-up", async () => {
+		const tracker = app.get(DatabaseHookTrackerService);
+		const before = tracker.getCalls("before", "user", "create").length;
+
+		await request(app.getHttpServer())
+			.post("/api/auth/sign-up/email")
+			.set("Content-Type", "application/json")
+			.send({
+				name: faker.person.fullName(),
+				email: faker.internet.email(),
+				password: faker.internet.password({ length: 10 }),
+			})
+			.expect(200);
+
+		expect(tracker.getCalls("before", "user", "create").length).toBe(
+			before + 1,
+		);
+	});
+
+	it("should call @AfterCreate('user') on sign-up", async () => {
+		const tracker = app.get(DatabaseHookTrackerService);
+		const before = tracker.getCalls("after", "user", "create").length;
+
+		await request(app.getHttpServer())
+			.post("/api/auth/sign-up/email")
+			.set("Content-Type", "application/json")
+			.send({
+				name: faker.person.fullName(),
+				email: faker.internet.email(),
+				password: faker.internet.password({ length: 10 }),
+			})
+			.expect(200);
+
+		expect(tracker.getCalls("after", "user", "create").length).toBe(before + 1);
+	});
+
+	it("should call @AfterCreate('session') on sign-up", async () => {
+		const tracker = app.get(DatabaseHookTrackerService);
+		const before = tracker.getCalls("after", "session", "create").length;
+
+		await request(app.getHttpServer())
+			.post("/api/auth/sign-up/email")
+			.set("Content-Type", "application/json")
+			.send({
+				name: faker.person.fullName(),
+				email: faker.internet.email(),
+				password: faker.internet.password({ length: 10 }),
+			})
+			.expect(200);
+
+		expect(tracker.getCalls("after", "session", "create").length).toBe(
+			before + 1,
+		);
+	});
+
+	it("should support dependency injection in database hook providers", async () => {
+		const tracker = app.get(DatabaseHookTrackerService);
+		expect(tracker).toBeInstanceOf(DatabaseHookTrackerService);
+
+		const beforeCount = tracker.calls.length;
+
+		await request(app.getHttpServer())
+			.post("/api/auth/sign-up/email")
+			.set("Content-Type", "application/json")
+			.send({
+				name: faker.person.fullName(),
+				email: faker.internet.email(),
+				password: faker.internet.password({ length: 10 }),
+			})
+			.expect(200);
+
+		// DI works: tracker was injected and received calls
+		expect(tracker.calls.length).toBeGreaterThan(beforeCount);
+	});
+});
+
+describe("database hooks configuration validation", () => {
+	it("should throw if database hook providers exist without databaseHooks configured", async () => {
+		const auth = betterAuth({
+			basePath: "/api/auth",
+			emailAndPassword: { enabled: true },
+			plugins: [bearer()],
+			// intentionally DO NOT set databaseHooks: {}
+		});
+
+		@Module({
+			imports: [AuthModule.forRoot({ auth })],
+			providers: [DatabaseHookTrackerService, UserDatabaseHook],
+		})
+		class AppModule {}
+
+		const moduleRef = await Test.createTestingModule({
+			imports: [AppModule],
+		}).compile();
+
+		const app = await createTestNestApplication(moduleRef, {
+			initialize: false,
+		});
+
+		await expect(app.init()).rejects.toThrow(
+			/@DatabaseHook providers.*databaseHooks.*not configured/i,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `@DatabaseHook()`, `@BeforeDatabaseHook(model, operation)`, and `@AfterDatabaseHook(model, operation)` decorators that mirror the existing `@Hook()` / `@BeforeHook()` / `@AfterHook()` system for better-auth's `databaseHooks` lifecycle
- Supports all 4 models (`user`, `session`, `account`, `verification`) and all 3 operations (`create`, `update`, `delete`)
- Uses the same discovery pattern (DiscoveryService + MetadataScanner) and chains with any user-defined database hooks

### Usage

```typescript
@DatabaseHook()
@Injectable()
class MyDatabaseHooks {
    constructor(private readonly emailService: EmailService) {}

    @BeforeDatabaseHook("user", "create")
    async beforeUserCreate(user, ctx) {
        return { data: { ...user, firstName: user.name.split(" ")[0] } };
    }

    @AfterDatabaseHook("user", "create")
    async afterUserCreate(user, ctx) {
        await this.emailService.sendWelcomeEmail(user.email);
    }
}
```

Closes #32