### PR TITLE
Fix Fastify Better Auth route CORS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ The available options are:
 
 | Option                      | Default | Description                                                                                                                                                              |
 | --------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `disableTrustedOriginsCors` | `false` | When set to `true`, disables the library's automatic CORS handling for the origins specified in `trustedOrigins`. On Fastify, leave this as `false` in the common case, even when your app already registers `@fastify/cors`: this library applies Better Auth route CORS separately from your app-level Fastify CORS. |
+| `disableTrustedOriginsCors` | `false` | When set to `true`, disables the automatic CORS configuration for the origins specified in `trustedOrigins`. On Fastify, use this only if you want to fully manage Better Auth route CORS yourself. |
 | `bodyParser`                | Re-adds JSON and URL-encoded body parsers | Configure the body parsers re-added by the module after Nest body parsing is disabled. `json` and `urlencoded` accept the parser options object plus `enabled?: boolean`, and `rawBody?: boolean` enables `req.rawBody`. |
 | `disableBodyParser`         | `false` | Deprecated. Use `bodyParser.json.enabled` and `bodyParser.urlencoded.enabled` instead. When set to `true`, disables both parsers unless you explicitly re-enable one in `bodyParser`. |
 | `enableRawBodyParser`       | `false` | Deprecated. Use `bodyParser.rawBody` instead. When set to `true`, enables raw body parsing and attaches the raw buffer to `req.rawBody`. |
@@ -706,11 +706,10 @@ On Fastify, Better Auth routes are served through middleware internally. Because
 
 - app-level `@fastify/cors` does not fully apply to Better Auth routes on its own
 - this module applies Better Auth route CORS from `trustedOrigins`
-- this module does not register Fastify CORS for you; it only applies Better Auth route CORS from `trustedOrigins`
-- because of that, you usually do not need `disableTrustedOriginsCors: true` just because your app already enables Fastify CORS
-- set `disableTrustedOriginsCors: true` only if you want to disable library-managed Better Auth route CORS entirely
 
 This Fastify fallback only supports array-based `trustedOrigins`. Function-based `trustedOrigins` remain unsupported unless you set `disableTrustedOriginsCors: true` and manage Better Auth route CORS manually.
+
+Set `disableTrustedOriginsCors: true` only if you want to fully manage Better Auth route CORS yourself.
 
 ### Using Custom Middleware
 

--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ The available options are:
 
 | Option                      | Default | Description                                                                                                                                                              |
 | --------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `disableTrustedOriginsCors` | `false` | When set to `true`, disables the automatic CORS configuration for the origins specified in `trustedOrigins`. On Fastify, use this only if you want to fully manage Better Auth route CORS yourself. |
+| `disableTrustedOriginsCors` | `false` | When set to `true`, disables the library's automatic CORS handling for the origins specified in `trustedOrigins`. On Fastify, leave this as `false` in the common case, even when your app already registers `@fastify/cors`: this library applies Better Auth route CORS separately from your app-level Fastify CORS. |
 | `bodyParser`                | Re-adds JSON and URL-encoded body parsers | Configure the body parsers re-added by the module after Nest body parsing is disabled. `json` and `urlencoded` accept the parser options object plus `enabled?: boolean`, and `rawBody?: boolean` enables `req.rawBody`. |
 | `disableBodyParser`         | `false` | Deprecated. Use `bodyParser.json.enabled` and `bodyParser.urlencoded.enabled` instead. When set to `true`, disables both parsers unless you explicitly re-enable one in `bodyParser`. |
 | `enableRawBodyParser`       | `false` | Deprecated. Use `bodyParser.rawBody` instead. When set to `true`, enables raw body parsing and attaches the raw buffer to `req.rawBody`. |
@@ -706,11 +706,11 @@ On Fastify, Better Auth routes are served through middleware internally. Because
 
 - app-level `@fastify/cors` does not fully apply to Better Auth routes on its own
 - this module applies Better Auth route CORS from `trustedOrigins`
-- if `@fastify/cors` is already registered, this module skips duplicate Fastify CORS registration and logs a warning once
+- this module does not register Fastify CORS for you; it only applies Better Auth route CORS from `trustedOrigins`
+- because of that, you usually do not need `disableTrustedOriginsCors: true` just because your app already enables Fastify CORS
+- set `disableTrustedOriginsCors: true` only if you want to disable library-managed Better Auth route CORS entirely
 
 This Fastify fallback only supports array-based `trustedOrigins`. Function-based `trustedOrigins` remain unsupported unless you set `disableTrustedOriginsCors: true` and manage Better Auth route CORS manually.
-
-Set `disableTrustedOriginsCors: true` only if you want to fully manage Better Auth route CORS yourself.
 
 ### Using Custom Middleware
 

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -27,9 +27,7 @@ import {
 } from "./auth-module-definition.ts";
 import { AuthService } from "./auth-service.ts";
 import { configureFastifyBodyParser } from "./fastify-body-parser.ts";
-import {
-	handleFastifyTrustedOriginsCors,
-} from "./fastify-trusted-origins-cors.ts";
+import { handleFastifyTrustedOriginsCors } from "./fastify-trusted-origins-cors.ts";
 import {
 	SkipBodyParsingMiddleware,
 	getNodeRequest,

--- a/src/auth-module.ts
+++ b/src/auth-module.ts
@@ -28,10 +28,12 @@ import {
 import { AuthService } from "./auth-service.ts";
 import { configureFastifyBodyParser } from "./fastify-body-parser.ts";
 import {
+	handleFastifyTrustedOriginsCors,
+} from "./fastify-trusted-origins-cors.ts";
+import {
 	SkipBodyParsingMiddleware,
 	getNodeRequest,
 	getNodeResponse,
-	handleFastifyTrustedOriginsCors,
 	matchesBasePath,
 	resolveBodyParserOptions,
 } from "./middlewares.ts";
@@ -188,26 +190,7 @@ export class AuthModule
 		const isNotFunctionBased = trustedOrigins && Array.isArray(trustedOrigins);
 
 		if (!this.options.disableTrustedOriginsCors && isNotFunctionBased) {
-			if (adapterType === "fastify") {
-				const fastifyInstance = this.adapter.httpAdapter.getInstance<{
-					hasRequestDecorator?: (name: string) => boolean;
-				}>();
-				const hasFastifyCorsRegistered =
-					fastifyInstance?.hasRequestDecorator?.("corsPreflightEnabled") ??
-					false;
-
-				if (hasFastifyCorsRegistered) {
-					this.logger.warn(
-						"Detected an existing @fastify/cors registration. Skipping automatic Fastify CORS registration for Better Auth trustedOrigins to avoid duplicate plugin registration. Better Auth routes will still apply CORS from trustedOrigins. Set disableTrustedOriginsCors: true if you want to fully manage Better Auth CORS yourself.",
-					);
-				} else {
-					this.adapter.httpAdapter.enableCors({
-						origin: trustedOrigins,
-						methods: ["GET", "POST", "PUT", "DELETE"],
-						credentials: true,
-					});
-				}
-			} else {
+			if (adapterType !== "fastify") {
 				this.adapter.httpAdapter.enableCors({
 					origin: trustedOrigins,
 					methods: ["GET", "POST", "PUT", "DELETE"],

--- a/src/fastify-trusted-origins-cors.ts
+++ b/src/fastify-trusted-origins-cors.ts
@@ -1,0 +1,114 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { getNodeRequest, getNodeResponse } from "./middlewares.ts";
+
+type RequestLike = IncomingMessage & {
+	raw?: IncomingMessage;
+	headers: IncomingMessage["headers"];
+	method?: string;
+};
+
+type ResponseLike = ServerResponse<IncomingMessage> & {
+	raw?: ServerResponse<IncomingMessage>;
+};
+
+type NodeResponseLike = ServerResponse<IncomingMessage> & {
+	getHeader(name: string): number | string | string[] | undefined;
+	setHeader(name: string, value: number | string | readonly string[]): this;
+	statusCode: number;
+};
+
+function getHeaderValue(header: string | string[] | undefined) {
+	if (Array.isArray(header)) {
+		return header.join(", ");
+	}
+
+	return header;
+}
+
+function appendVaryHeader(res: NodeResponseLike, value: string) {
+	const currentHeader = res.getHeader("Vary");
+	const currentValue =
+		typeof currentHeader === "number"
+			? String(currentHeader)
+			: Array.isArray(currentHeader)
+				? currentHeader.join(", ")
+				: currentHeader;
+
+	const varyValues = new Set(
+		currentValue
+			?.split(",")
+			.map((item) => item.trim())
+			.filter(Boolean) ?? [],
+	);
+	varyValues.add(value);
+
+	res.setHeader("Vary", Array.from(varyValues).join(", "));
+}
+
+function escapeRegex(pattern: string) {
+	return pattern.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function matchesOriginPattern(origin: string, pattern: string) {
+	if (pattern === "*") return true;
+
+	const regex = new RegExp(
+		`^${pattern.split("*").map(escapeRegex).join(".*")}$`,
+	);
+	return regex.test(origin);
+}
+
+function isAllowedOrigin(origin: string, trustedOrigins: string[]) {
+	return trustedOrigins.some((trustedOrigin) =>
+		matchesOriginPattern(origin, trustedOrigin),
+	);
+}
+
+export interface FastifyTrustedOriginsCorsOptions {
+	trustedOrigins: string[];
+}
+
+export function handleFastifyTrustedOriginsCors(
+	req: RequestLike,
+	res: ResponseLike,
+	options: FastifyTrustedOriginsCorsOptions,
+) {
+	const nodeReq = getNodeRequest(req) as RequestLike;
+	const nodeRes = getNodeResponse(res) as NodeResponseLike;
+	const origin = getHeaderValue(nodeReq.headers.origin);
+
+	if (!origin || !isAllowedOrigin(origin, options.trustedOrigins)) {
+		return false;
+	}
+
+	nodeRes.setHeader("Access-Control-Allow-Origin", origin);
+	nodeRes.setHeader("Access-Control-Allow-Credentials", "true");
+	appendVaryHeader(nodeRes, "Origin");
+
+	if (nodeReq.method?.toUpperCase() !== "OPTIONS") {
+		return false;
+	}
+
+	const requestMethod = getHeaderValue(
+		nodeReq.headers["access-control-request-method"],
+	);
+	const requestHeaders = getHeaderValue(
+		nodeReq.headers["access-control-request-headers"],
+	);
+
+	nodeRes.setHeader(
+		"Access-Control-Allow-Methods",
+		requestMethod ?? "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS",
+	);
+
+	if (requestHeaders) {
+		nodeRes.setHeader("Access-Control-Allow-Headers", requestHeaders);
+		appendVaryHeader(nodeRes, "Access-Control-Request-Headers");
+	}
+
+	nodeRes.statusCode = 204;
+	nodeRes.setHeader("Content-Length", "0");
+	nodeRes.end();
+
+	return true;
+}

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -61,12 +61,6 @@ type NodeRequestLike = IncomingMessage & {
 	headers: IncomingMessage["headers"];
 };
 
-type NodeResponseLike = ServerResponse<IncomingMessage> & {
-	getHeader(name: string): number | string | string[] | undefined;
-	setHeader(name: string, value: number | string | readonly string[]): this;
-	statusCode: number;
-};
-
 function getExpressBodyParser(): ExpressBodyParserModule {
 	return require("express") as ExpressBodyParserModule;
 }
@@ -138,102 +132,6 @@ export function matchesBasePath(req: RequestLike, basePath: string) {
 	const requestPath = getRequestPath(req);
 
 	return requestPath === basePath || requestPath.startsWith(`${basePath}/`);
-}
-
-function getHeaderValue(header: string | string[] | undefined) {
-	if (Array.isArray(header)) {
-		return header.join(", ");
-	}
-
-	return header;
-}
-
-function appendVaryHeader(res: NodeResponseLike, value: string) {
-	const currentHeader = res.getHeader("Vary");
-	const currentValue =
-		typeof currentHeader === "number"
-			? String(currentHeader)
-			: Array.isArray(currentHeader)
-				? currentHeader.join(", ")
-				: currentHeader;
-
-	const varyValues = new Set(
-		currentValue
-			?.split(",")
-			.map((item) => item.trim())
-			.filter(Boolean) ?? [],
-	);
-	varyValues.add(value);
-
-	res.setHeader("Vary", Array.from(varyValues).join(", "));
-}
-
-function escapeRegex(pattern: string) {
-	return pattern.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
-}
-
-function matchesOriginPattern(origin: string, pattern: string) {
-	if (pattern === "*") return true;
-
-	const regex = new RegExp(
-		`^${pattern.split("*").map(escapeRegex).join(".*")}$`,
-	);
-	return regex.test(origin);
-}
-
-function isAllowedOrigin(origin: string, trustedOrigins: string[]) {
-	return trustedOrigins.some((trustedOrigin) =>
-		matchesOriginPattern(origin, trustedOrigin),
-	);
-}
-
-export interface FastifyTrustedOriginsCorsOptions {
-	trustedOrigins: string[];
-}
-
-export function handleFastifyTrustedOriginsCors(
-	req: RequestLike,
-	res: ResponseLike,
-	options: FastifyTrustedOriginsCorsOptions,
-) {
-	const nodeReq = getNodeRequest(req) as NodeRequestLike;
-	const nodeRes = getNodeResponse(res) as NodeResponseLike;
-	const origin = getHeaderValue(nodeReq.headers.origin);
-
-	if (!origin || !isAllowedOrigin(origin, options.trustedOrigins)) {
-		return false;
-	}
-
-	nodeRes.setHeader("Access-Control-Allow-Origin", origin);
-	nodeRes.setHeader("Access-Control-Allow-Credentials", "true");
-	appendVaryHeader(nodeRes, "Origin");
-
-	if (nodeReq.method?.toUpperCase() !== "OPTIONS") {
-		return false;
-	}
-
-	const requestMethod = getHeaderValue(
-		nodeReq.headers["access-control-request-method"],
-	);
-	const requestHeaders = getHeaderValue(
-		nodeReq.headers["access-control-request-headers"],
-	);
-
-	nodeRes.setHeader(
-		"Access-Control-Allow-Methods",
-		requestMethod ?? "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS",
-	);
-
-	if (requestHeaders) {
-		nodeRes.setHeader("Access-Control-Allow-Headers", requestHeaders);
-		appendVaryHeader(nodeRes, "Access-Control-Request-Headers");
-	}
-
-	nodeRes.statusCode = 204;
-	nodeRes.setHeader("Content-Length", "0");
-	nodeRes.end();
-
-	return true;
 }
 
 /**

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -56,11 +56,6 @@ type ResponseLike = ServerResponse<IncomingMessage> & {
 	raw?: ServerResponse<IncomingMessage>;
 };
 
-type NodeRequestLike = IncomingMessage & {
-	method?: string;
-	headers: IncomingMessage["headers"];
-};
-
 function getExpressBodyParser(): ExpressBodyParserModule {
 	return require("express") as ExpressBodyParserModule;
 }

--- a/tests/e2e/cors.e2e.test.ts
+++ b/tests/e2e/cors.e2e.test.ts
@@ -1,4 +1,3 @@
-import { Logger } from "@nestjs/common";
 import cors from "@fastify/cors";
 import request from "supertest";
 import { vi } from "vitest";
@@ -61,12 +60,8 @@ describe("cors e2e", () => {
 	});
 
 	fastifyOnly(
-		"should warn and skip duplicate Fastify CORS registration when @fastify/cors is already registered",
+		"should coexist with app-level Fastify CORS when @fastify/cors is already registered",
 		async () => {
-			const warnSpy = vi
-				.spyOn(Logger.prototype, "warn")
-				.mockImplementation(() => undefined);
-
 			testSetup = await createTestApp(undefined, false, {
 				authOptions: {
 					trustedOrigins: [TRUSTED_ORIGIN],
@@ -78,14 +73,6 @@ describe("cors e2e", () => {
 					});
 				},
 			});
-
-			const warningCalls = warnSpy.mock.calls.filter(([message]) =>
-				String(message).includes(
-					"Detected an existing @fastify/cors registration.",
-				),
-			);
-
-			expect(warningCalls).toHaveLength(1);
 
 			const httpServer = testSetup.app.getHttpServer();
 			const optionsResponse = await request(httpServer)

--- a/tests/e2e/database-hooks.e2e.test.ts
+++ b/tests/e2e/database-hooks.e2e.test.ts
@@ -10,10 +10,6 @@ import {
 	DatabaseHook,
 	BeforeCreate,
 	AfterCreate,
-	BeforeUpdate,
-	AfterUpdate,
-	BeforeDelete,
-	AfterDelete,
 } from "../../src/index.ts";
 import { createTestNestApplication } from "../shared/test-utils.ts";
 


### PR DESCRIPTION
## Summary

This fixes Fastify CORS handling for Better Auth routes without relying on library-side Fastify CORS plugin registration.

## What Changed

- moved the Fastify Better Auth route CORS logic into a dedicated helper
- stopped calling Fastify `enableCors()` from `nestjs-better-auth`
- kept Better Auth route CORS handling on the middleware path using `trustedOrigins`
- kept `disableTrustedOriginsCors` as the switch that fully disables library-managed CORS
- updated the Fastify CORS test coverage and README behavior notes

## Root Cause

On Fastify, Better Auth routes are served through middleware/raw response handling rather than normal Fastify route handling. Because of that, app-level `@fastify/cors` does not fully cover Better Auth routes by itself.

The old implementation also tried to register Fastify CORS from the library. That created two problems:

- duplicate Fastify CORS registration conflicts when the host app already enabled CORS
- pressure on users to set `disableTrustedOriginsCors: true`, which then disabled library-managed Better Auth route CORS entirely

## Result

- users can keep app-level Fastify CORS enabled without needing the library to register Fastify CORS too
- Better Auth routes still get CORS from `trustedOrigins` when library-managed CORS is enabled
- `disableTrustedOriginsCors: true` still works if users explicitly want the library's Better Auth CORS off

## Validation

- `npm run build`
- `npm run test:fastify`
