### PR TITLE
Declare missing express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
 		"unplugin-swc": "^1.5.7",
 		"vitest": "^3.2.4"
 	},
+	"dependencies": {
+		"express": "^5.2.1"
+	},
 	"peerDependencies": {
 		"@nestjs/common": "^11.1.6",
 		"@nestjs/core": "^11.1.6",


### PR DESCRIPTION
## Summary
Declares the missing `express` dependency.

## Problem reproduction
The candidate reports a missing-module failure. Running `npm run build` reproduced or confirmed the missing `express` dependency path.

## Fix
Added `express` to dependencies with the current npm version.

## Validation
- `npm install --ignore-scripts --no-audit --no-fund --package-lock=false`
- `npm run build`

## Known limitations
None for the scoped fix.

## Safety
This change uses only public repository/package metadata, public source files, and local validation commands.