### PR TITLE
[codex] Use body-parser for middleware parsing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "@thallesp/nestjs-better-auth",
+      "dependencies": {
+        "body-parser": "^2.2.1",
+      },
       "devDependencies": {
         "@apollo/server": "^5.0.0",
         "@as-integrations/express5": "^1.1.2",
@@ -20,6 +23,7 @@
         "@swc/cli": "^0.7.8",
         "@swc/core": "^1.13.20",
         "@tsconfig/node22": "^22.0.2",
+        "@types/body-parser": "^1.19.6",
         "@types/bun": "latest",
         "@types/express": "^5.0.3",
         "@types/supertest": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
 	"engines": {
 		"node": ">=22.22.1"
 	},
+	"dependencies": {
+		"body-parser": "^2.2.1"
+	},
 	"packageManager": "bun@1.3.14",
 	"keywords": [
 		"nestjs",
@@ -54,6 +57,7 @@
 		"@swc/cli": "^0.7.8",
 		"@swc/core": "^1.13.20",
 		"@tsconfig/node22": "^22.0.2",
+		"@types/body-parser": "^1.19.6",
 		"@types/bun": "latest",
 		"@types/express": "^5.0.3",
 		"@types/supertest": "^6.0.3",

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -1,12 +1,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { createRequire } from "node:module";
+import bodyParser from "body-parser";
 import type { AuthModuleOptions } from "./auth-module-definition.ts";
 import type {
 	JsonBodyParserOptions,
 	UrlencodedBodyParserOptions,
 } from "./body-parser-options.ts";
-
-const require = createRequire(import.meta.url);
 
 type MiddlewareNext = (error?: unknown) => void;
 type BodyParserHandler = (
@@ -56,8 +54,8 @@ type ResponseLike = ServerResponse<IncomingMessage> & {
 	raw?: ServerResponse<IncomingMessage>;
 };
 
-function getExpressBodyParser(): ExpressBodyParserModule {
-	return require("express") as ExpressBodyParserModule;
+function getBodyParser(): ExpressBodyParserModule {
+	return bodyParser as ExpressBodyParserModule;
 }
 
 export type ResolvedJsonBodyParserOptions = JsonBodyParserOptions & {
@@ -138,7 +136,7 @@ export function SkipBodyParsingMiddleware(
 ) {
 	const { basePath = "/api/auth", bodyParser = resolveBodyParserOptions() } =
 		options;
-	const express = getExpressBodyParser();
+	const parser = getBodyParser();
 
 	const {
 		enabled: jsonEnabled,
@@ -152,10 +150,10 @@ export function SkipBodyParsingMiddleware(
 		? { ...jsonParserOptions, verify: rawBodyParser }
 		: jsonParserOptions;
 	const jsonParser = jsonEnabled
-		? express.json(expressJsonParserOptions as never)
+		? parser.json(expressJsonParserOptions as never)
 		: null;
 	const urlencodedParser = urlencodedEnabled
-		? express.urlencoded(urlencodedParserOptions as never)
+		? parser.urlencoded(urlencodedParserOptions as never)
 		: null;
 
 	return (req: RequestLike, res: ResponseLike, next: MiddlewareNext): void => {


### PR DESCRIPTION
## Summary

Replace the Express package require used by `SkipBodyParsingMiddleware` with a direct `body-parser` dependency.

## Root Cause

`SkipBodyParsingMiddleware` only needs `json()` and `urlencoded()`, but it resolved them through `createRequire(import.meta.url)("express")`. When downstream apps bundle the package with Vite and do not ship the optional `express` peer, the bundled server can fail at runtime with `Cannot find module 'express'`.

## Impact

Bundled NestJS apps can use the Express adapter middleware path without needing to install the full optional `express` package just for body parsing.

Fixes #147.

## Validation

- `bun run build`
- `bun run test`
- `bun run check`
- Reproduced the Vite SSR bundled runtime failure without `express`, then verified the same repro succeeds with this change.
