### PR TITLE
Add RequireActiveOrg decorator for active organization-only routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ This library provides two role decorators for different use cases:
 | Decorator | Checks | Use Case |
 |-----------|--------|----------|
 | `@Roles()` | `user.role` only | System-level roles ([admin plugin](https://www.better-auth.com/docs/plugins/admin)) |
-| `@OrgRoles()` | Organization member role only | Organization-level roles ([organization plugin](https://www.better-auth.com/docs/plugins/organization)) |
+| `@RequireActiveOrg()` | Active organization only | Routes that only need `activeOrganizationId` for scoping |
+| `@OrgRoles()` | Active organization + organization member role | Organization-level roles ([organization plugin](https://www.better-auth.com/docs/plugins/organization)) |
 
 > [!IMPORTANT]
 > These decorators are intentionally **separate** to prevent privilege escalation. The `@Roles()` decorator only checks `user.role` and does **not** check organization member roles. This ensures an organization admin cannot bypass system-level admin protection.
@@ -211,9 +212,33 @@ export class AdminController {
 }
 ```
 
+#### @RequireActiveOrg() - Active Organization Only
+
+Use `@RequireActiveOrg()` when a route or controller only needs an active organization context. This requires authentication and `session.activeOrganizationId`, but does not require any specific organization role.
+
+```ts title="projects.controller.ts"
+import { Controller, Get } from "@nestjs/common";
+import {
+  RequireActiveOrg,
+  Session,
+  UserSession,
+} from "@thallesp/nestjs-better-auth";
+
+@RequireActiveOrg()
+@Controller("projects")
+export class ProjectsController {
+  @Get()
+  async listProjects(@Session() session: UserSession) {
+    return { orgId: session.session.activeOrganizationId };
+  }
+}
+```
+
+Use this when the controller only needs an active organization ID for scoping data, but authorization is handled elsewhere or organization roles are dynamic.
+
 #### @OrgRoles() - Organization-Level Roles
 
-Use `@OrgRoles()` for organization-scoped protection. This checks only the organization member role and requires an active organization (`activeOrganizationId` in session).
+Use `@OrgRoles()` for organization-scoped protection when you want to require an active organization and one of the specified organization member roles.
 
 ```ts title="org.controller.ts"
 import { Controller, Get } from "@nestjs/common";

--- a/src/auth-guard.ts
+++ b/src/auth-guard.ts
@@ -169,6 +169,17 @@ export class AuthGuard implements CanActivate {
 			request.headers || request?.handshake?.headers || [],
 		);
 
+		const requireActiveOrg = this.reflector.getAllAndOverride<boolean>(
+			"REQUIRE_ACTIVE_ORG",
+			[context.getHandler(), context.getClass()],
+		);
+
+		if (requireActiveOrg && !session.session?.activeOrganizationId) {
+			throw await AuthContextErrorMap[ctxType].FORBIDDEN({
+				message: "Active organization is required",
+			});
+		}
+
 		// Check @Roles() - user.role only (admin plugin)
 		const requiredRoles = this.reflector.getAllAndOverride<string[]>("ROLES", [
 			context.getHandler(),

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,4 +1,8 @@
-import { SetMetadata, createParamDecorator } from "@nestjs/common";
+import {
+	SetMetadata,
+	applyDecorators,
+	createParamDecorator,
+} from "@nestjs/common";
 import type { CustomDecorator, ExecutionContext } from "@nestjs/common";
 import type { createAuthMiddleware } from "better-auth/api";
 import {
@@ -25,6 +29,13 @@ export const AllowAnonymous = (): CustomDecorator<string> =>
  */
 export const OptionalAuth = (): CustomDecorator<string> =>
 	SetMetadata("OPTIONAL", true);
+
+/**
+ * Requires an authenticated session with an active organization selected.
+ * Does not check for any specific organization role.
+ */
+export const RequireActiveOrg = (): CustomDecorator<string> =>
+	SetMetadata("REQUIRE_ACTIVE_ORG", true);
 
 /**
  * Specifies the user-level roles required to access a route or controller.
@@ -56,7 +67,7 @@ export const Roles = (roles: string[]): CustomDecorator =>
  * ```
  */
 export const OrgRoles = (roles: string[]): CustomDecorator =>
-	SetMetadata("ORG_ROLES", roles);
+	applyDecorators(RequireActiveOrg(), SetMetadata("ORG_ROLES", roles));
 
 /**
  * Type for permission checks - maps resource names to arrays of actions

--- a/tests/e2e/organization-roles.e2e.test.ts
+++ b/tests/e2e/organization-roles.e2e.test.ts
@@ -7,7 +7,10 @@ import { bearer } from "better-auth/plugins/bearer";
 import { organization } from "better-auth/plugins/organization";
 import { admin } from "better-auth/plugins/admin";
 import { AuthModule } from "../../src/index.ts";
-import { TestController } from "../shared/test-controller.ts";
+import {
+	ActiveOrgController,
+	TestController,
+} from "../shared/test-controller.ts";
 import { createTestNestApplication } from "../shared/test-utils.ts";
 
 /**
@@ -37,7 +40,7 @@ async function createTestAppWithOrganization() {
 
 	@Module({
 		imports: [AuthModule.forRoot({ auth })],
-		controllers: [TestController],
+		controllers: [TestController, ActiveOrgController],
 	})
 	class AppModule {}
 
@@ -424,6 +427,190 @@ describe("organization roles e2e", () => {
 			expect(response.body).toMatchObject({
 				user: expect.objectContaining({
 					id: memberSignUp.user.id,
+				}),
+			});
+		});
+	});
+
+	describe("@RequireActiveOrg()", () => {
+		it("should forbid access when session has no active organization", async () => {
+			const signUp = await testSetup.auth.api.signUpEmail({
+				body: {
+					name: faker.person.fullName(),
+					email: faker.internet.email(),
+					password: faker.internet.password({ length: 10 }),
+				},
+			});
+
+			await request(testSetup.app.getHttpServer())
+				.get("/test/active-org-protected")
+				.set("Authorization", `Bearer ${signUp.token}`)
+				.expect(403)
+				.expect((res) => {
+					expect(res.body?.message).toContain(
+						"Active organization is required",
+					);
+				});
+		});
+
+		it("should allow access when session has an active organization", async () => {
+			const signUp = await testSetup.auth.api.signUpEmail({
+				body: {
+					name: faker.person.fullName(),
+					email: faker.internet.email(),
+					password: faker.internet.password({ length: 10 }),
+				},
+			});
+
+			// biome-ignore lint/suspicious/noExplicitAny: API types vary by plugin
+			const authApi = testSetup.auth.api as any;
+
+			const org = await authApi.createOrganization({
+				body: {
+					name: "Active Org Route",
+					slug: `active-org-route-${Date.now()}`,
+				},
+				headers: {
+					Authorization: `Bearer ${signUp.token}`,
+				},
+			});
+
+			await authApi.setActiveOrganization({
+				body: {
+					organizationId: org.id,
+				},
+				headers: {
+					Authorization: `Bearer ${signUp.token}`,
+				},
+			});
+
+			const response = await request(testSetup.app.getHttpServer())
+				.get("/test/active-org-protected")
+				.set("Authorization", `Bearer ${signUp.token}`)
+				.expect(200);
+
+			expect(response.body).toMatchObject({
+				user: expect.objectContaining({
+					id: signUp.user.id,
+				}),
+				session: expect.objectContaining({
+					session: expect.objectContaining({
+						activeOrganizationId: org.id,
+					}),
+				}),
+			});
+		});
+
+		it("should not require any specific org role", async () => {
+			const ownerSignUp = await testSetup.auth.api.signUpEmail({
+				body: {
+					name: faker.person.fullName(),
+					email: faker.internet.email(),
+					password: faker.internet.password({ length: 10 }),
+				},
+			});
+
+			const memberSignUp = await testSetup.auth.api.signUpEmail({
+				body: {
+					name: faker.person.fullName(),
+					email: faker.internet.email(),
+					password: faker.internet.password({ length: 10 }),
+				},
+			});
+
+			// biome-ignore lint/suspicious/noExplicitAny: API types vary by plugin
+			const authApi = testSetup.auth.api as any;
+
+			const org = await authApi.createOrganization({
+				body: {
+					name: "Active Org Member Access",
+					slug: `active-org-member-${Date.now()}`,
+				},
+				headers: {
+					Authorization: `Bearer ${ownerSignUp.token}`,
+				},
+			});
+
+			await authApi.addMember({
+				body: {
+					userId: memberSignUp.user.id,
+					organizationId: org.id,
+					role: "member",
+				},
+			});
+
+			await authApi.setActiveOrganization({
+				body: {
+					organizationId: org.id,
+				},
+				headers: {
+					Authorization: `Bearer ${memberSignUp.token}`,
+				},
+			});
+
+			const response = await request(testSetup.app.getHttpServer())
+				.get("/test/active-org-protected")
+				.set("Authorization", `Bearer ${memberSignUp.token}`)
+				.expect(200);
+
+			expect(response.body).toMatchObject({
+				user: expect.objectContaining({
+					id: memberSignUp.user.id,
+				}),
+				session: expect.objectContaining({
+					session: expect.objectContaining({
+						activeOrganizationId: org.id,
+					}),
+				}),
+			});
+		});
+
+		it("should support controller-level protection", async () => {
+			const signUp = await testSetup.auth.api.signUpEmail({
+				body: {
+					name: faker.person.fullName(),
+					email: faker.internet.email(),
+					password: faker.internet.password({ length: 10 }),
+				},
+			});
+
+			// biome-ignore lint/suspicious/noExplicitAny: API types vary by plugin
+			const authApi = testSetup.auth.api as any;
+
+			await request(testSetup.app.getHttpServer())
+				.get("/active-org-controller/projects")
+				.set("Authorization", `Bearer ${signUp.token}`)
+				.expect(403);
+
+			const org = await authApi.createOrganization({
+				body: {
+					name: "Controller Active Org",
+					slug: `controller-active-org-${Date.now()}`,
+				},
+				headers: {
+					Authorization: `Bearer ${signUp.token}`,
+				},
+			});
+
+			await authApi.setActiveOrganization({
+				body: {
+					organizationId: org.id,
+				},
+				headers: {
+					Authorization: `Bearer ${signUp.token}`,
+				},
+			});
+
+			const response = await request(testSetup.app.getHttpServer())
+				.get("/active-org-controller/projects")
+				.set("Authorization", `Bearer ${signUp.token}`)
+				.expect(200);
+
+			expect(response.body).toMatchObject({
+				session: expect.objectContaining({
+					session: expect.objectContaining({
+						activeOrganizationId: org.id,
+					}),
 				}),
 			});
 		});

--- a/tests/shared/test-controller.ts
+++ b/tests/shared/test-controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Post, Request } from "@nestjs/common";
 import {
 	OptionalAuth,
 	AllowAnonymous,
+	RequireActiveOrg,
 	Roles,
 	OrgRoles,
 } from "../../src/decorators.ts";
@@ -47,6 +48,12 @@ export class TestController {
 	@Get("admin-moderator-protected")
 	adminModeratorProtected(@Request() req: UserSession) {
 		return { user: req.user };
+	}
+
+	@RequireActiveOrg()
+	@Get("active-org-protected")
+	activeOrgProtected(@Request() req: UserSession) {
+		return { user: req.user, session: req.session };
 	}
 
 	@OrgRoles(["owner"])
@@ -99,5 +106,14 @@ export class TestController {
 			hasBody: body !== undefined,
 			body: body ?? null,
 		};
+	}
+}
+
+@RequireActiveOrg()
+@Controller("active-org-controller")
+export class ActiveOrgController {
+	@Get("projects")
+	projects(@Request() req: UserSession) {
+		return { user: req.user, session: req.session };
 	}
 }


### PR DESCRIPTION
## Summary

Adds a new `@RequireActiveOrg()` decorator for routes/controllers that require an active Better Auth organization context without requiring any specific organization role.

This is useful for applications with dynamic organization roles, or routes that only need `activeOrganizationId` for scoping data.

## Changes

- Added `RequireActiveOrg` decorator.
- Updated `OrgRoles` to also imply active organization requirement.
- Updated `AuthGuard` to enforce `REQUIRE_ACTIVE_ORG` metadata.
- Added tests for active organization-only route protection.
- Updated README documentation.

## Motivation

Previously, the only way to require an active organization context was to use `@OrgRoles(...)` with at least one static role. This does not work well for controllers that only need an active organization ID or for apps using dynamic organization roles.

## Validation

- `bun run lint`
- `bun run build`
- `bun run test`

Fixes #157.