### PR TITLE
fix(auth-guard): keep anonymous routes working when getSession fails (e.g. DB down)

### DIFF
--- a/src/auth-guard.ts
+++ b/src/auth-guard.ts
@@ -139,11 +139,26 @@ export class AuthGuard implements CanActivate {
 	 */
 	async canActivate(context: ExecutionContext): Promise<boolean> {
 		const request = await getRequestFromContext(context);
-		const session: UserSession | null = await this.options.auth.api.getSession({
-			headers: fromNodeHeaders(
-				request.headers || request?.handshake?.headers || [],
-			),
-		});
+
+		// Better Auth resolves getSession() to null for missing/invalid sessions and
+		// only rejects on infrastructure failures (e.g. an unreachable database).
+		// Capture that failure instead of letting it bubble up: routes that don't
+		// require a session (@AllowAnonymous / @OptionalAuth) must still proceed when
+		// the database is down (e.g. liveness/readiness probes), while routes that do
+		// require one still surface the original error. Mirrors the try/catch + log
+		// pattern already used by the role/permission checks below.
+		let session: UserSession | null = null;
+		let sessionError: unknown = null;
+		try {
+			session = await this.options.auth.api.getSession({
+				headers: fromNodeHeaders(
+					request.headers || request?.handshake?.headers || [],
+				),
+			});
+		} catch (error) {
+			sessionError = error;
+			console.error("Failed to retrieve session:", error);
+		}
 
 		request.session = session;
 		request.user = session?.user ?? null; // useful for observability tools like Sentry
@@ -163,6 +178,10 @@ export class AuthGuard implements CanActivate {
 		if (!session && isOptional) return true;
 
 		const ctxType = context.getType();
+		// The route requires a session. If it couldn't be retrieved because of an
+		// infrastructure error, surface that error (e.g. 500) instead of masking it
+		// as a 401 — the client's credentials aren't the problem, the server is.
+		if (sessionError) throw sessionError;
 		if (!session) throw await AuthContextErrorMap[ctxType].UNAUTHORIZED();
 
 		const headers = fromNodeHeaders(

--- a/tests/e2e/auth-guard-db-failure.e2e.test.ts
+++ b/tests/e2e/auth-guard-db-failure.e2e.test.ts
@@ -1,0 +1,55 @@
+import request from "supertest";
+import { vi } from "vitest";
+import { createTestApp, type TestAppSetup } from "../shared/test-utils.ts";
+
+// Regression test for https://github.com/ThallesP/nestjs-better-auth/issues/159
+//
+// When the database is unreachable, Better Auth's getSession() rejects instead of
+// resolving to null. The guard used to call getSession() before evaluating the
+// route metadata, so the rejection bubbled up as a 500 on every route — including
+// @AllowAnonymous() health/readiness probes whose whole purpose is to keep working
+// while the database is down.
+//
+// The guard must now:
+//  - let @AllowAnonymous() routes through regardless of the failure,
+//  - let @OptionalAuth() routes through as anonymous,
+//  - and still surface the failure on routes that actually require a session.
+describe("auth guard db failure e2e", () => {
+	let testSetup: TestAppSetup;
+
+	beforeAll(async () => {
+		testSetup = await createTestApp();
+		// Simulate an infrastructure failure: better-auth rejects instead of
+		// resolving to null (which is what it does for a missing/invalid session).
+		vi.spyOn(testSetup.auth.api, "getSession").mockRejectedValue(
+			new Error("simulated database connection failure"),
+		);
+	});
+
+	afterAll(async () => {
+		vi.restoreAllMocks();
+		await testSetup.app.close();
+	});
+
+	it("still serves @AllowAnonymous() routes when getSession throws", async () => {
+		const response = await request(testSetup.app.getHttpServer())
+			.get("/test/public")
+			.expect(200);
+
+		expect(response.body).toMatchObject({ ok: true });
+	});
+
+	it("still serves @OptionalAuth() routes as anonymous when getSession throws", async () => {
+		const response = await request(testSetup.app.getHttpServer())
+			.get("/test/optional")
+			.expect(200);
+
+		expect(response.body).toMatchObject({ authenticated: false });
+	});
+
+	it("surfaces the failure on protected routes when getSession throws", async () => {
+		await request(testSetup.app.getHttpServer())
+			.get("/test/protected")
+			.expect(500);
+	});
+});

--- a/tests/e2e/auth-guard-db-failure.e2e.test.ts
+++ b/tests/e2e/auth-guard-db-failure.e2e.test.ts
@@ -44,7 +44,10 @@ describe("auth guard db failure e2e", () => {
 			.get("/test/optional")
 			.expect(200);
 
-		expect(response.body).toMatchObject({ authenticated: false });
+		expect(response.body).toMatchObject({
+			authenticated: false,
+			session: null,
+		});
 	});
 
 	it("surfaces the failure on protected routes when getSession throws", async () => {


### PR DESCRIPTION
## Description

Closes #159.

### Problem

`AuthGuard.canActivate` calls `getSession()` **before** it reads the route metadata (`@AllowAnonymous()` / `@OptionalAuth()`). Because Better Auth's `getSession()` goes through the same database adapter, an infrastructure failure (e.g. an unreachable database) makes it **reject**. With no `try/catch` around it, that rejection bubbles up and NestJS turns it into a generic `500` on **every** route — including `@AllowAnonymous()` liveness/readiness probes, whose entire job is to keep responding while the database is down. The `isPublic` short-circuit is never reached.

### Approach

Wrap the `getSession()` call in a `try/catch` and evaluate the route metadata afterwards:

- On failure, fall back to a `null` session and log it — mirroring the `try/catch` + `console.error` pattern already used by the role/permission checks in this same guard.
- `@AllowAnonymous()` routes return `true` regardless of the failure. The session is still hydrated when the DB is up, so `@Session()` on public routes keeps working.
- `@OptionalAuth()` routes proceed as anonymous.
- Routes that **require** a session re-throw the original error, so a real DB outage surfaces as a `5xx` instead of a misleading `401` (which would push clients into a logout / redirect-to-login loop they can't escape while the DB is down). Protected-route behavior is otherwise unchanged.

No public API changes — the only observable difference is that anonymous/optional routes no longer `500` when the session lookup fails. It's a `patch`.

### Why not the alternatives raised in the issue thread

- **Reading `isPublic` first and skipping `getSession()` entirely** would break session hydration on public/optional routes: an authenticated user hitting a public route would lose `req.user` / `req.session` (the `@Session()` / optional-auth pattern).
- **A new `injectSessionInPublicRoutes` option** adds configuration surface for a false dichotomy — the `try/catch` already gives both behaviors (session hydrated when the DB is up, route still served when it's down) without a new flag to document, test and misconfigure.

### Tests

Added `tests/e2e/auth-guard-db-failure.e2e.test.ts` (runs on both Express and Fastify), simulating a rejecting `getSession()`:

- `@AllowAnonymous()` → `200`
- `@OptionalAuth()` → `200` (anonymous)
- protected → `500` (error surfaced, not masked)

@ThallesP would appreciate your review on this one 🙏

## Checklist

- [x] Addresses a real, reproducible problem (issue linked for non-trivial changes)
- [x] Used the project toolchain — **Bun** (not npm/yarn/pnpm)
- [x] `bun run check` passes (lint + format)
- [x] `bun run test` passes (Express + Fastify)
- [x] I understand & can maintain every line — including any AI-assisted parts
